### PR TITLE
🐛 再起不能状態でも行動選択肢が表示される問題を修正

### DIFF
--- a/src/game/scenes/BattleScene.ts
+++ b/src/game/scenes/BattleScene.ts
@@ -264,6 +264,7 @@ export class BattleScene {
         const canAct = this.player.canAct() && this.playerTurn && !this.battleEnded;
         const isRestrained = this.player.isRestrained() || this.player.isEaten() || this.player.isCocoon();
         const isKnockedOut = this.player.isKnockedOut();
+        const isDoomed = this.player.isDoomed();
         
         // Show/hide action panels
         if (this.actionButtons && this.specialActions && this.battleEndActions) {
@@ -272,7 +273,7 @@ export class BattleScene {
                 this.actionButtons.classList.add('d-none');
                 this.specialActions.classList.add('d-none');
                 this.battleEndActions.classList.remove('d-none');
-            } else if (isRestrained || isKnockedOut || this.player.statusEffects.isSleeping()) {
+            } else if (isRestrained || isKnockedOut || this.player.statusEffects.isSleeping() || isDoomed) {
                 this.actionButtons.classList.add('d-none');
                 this.specialActions.classList.remove('d-none');
                 this.battleEndActions.classList.add('d-none');
@@ -297,7 +298,15 @@ export class BattleScene {
         specialBtns.forEach(btnId => {
             const btn = document.getElementById(btnId);
             if (btn) {
-                if (isKnockedOut) {
+                if (isDoomed) {
+                    // For doomed state, only show give-up button
+                    if (btnId === 'struggle-btn' || btnId === 'stay-still-btn') {
+                        btn.classList.add('d-none');
+                    } else {
+                        btn.classList.remove('d-none');
+                        btn.classList.toggle('disabled', !this.playerTurn);
+                    }
+                } else if (isKnockedOut) {
                     // For knocked out state, only show give-up button
                     if (btnId === 'struggle-btn' || btnId === 'stay-still-btn') {
                         btn.classList.add('d-none');
@@ -417,7 +426,8 @@ export class BattleScene {
         const struggleSkillSpecialBtn = document.getElementById('struggle-skill-special-btn');
         if (struggleSkillSpecialBtn) {
             const canUseSkill = !this.player.statusEffects.isExhausted() && 
-                               !this.player.statusEffects.isKnockedOut();
+                               !this.player.statusEffects.isKnockedOut() &&
+                               !this.player.statusEffects.isDoomed();
             if (canUseSkill) {
                 struggleSkillSpecialBtn.classList.remove('d-none');
                 struggleSkillSpecialBtn.classList.toggle('disabled', !this.playerTurn);


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 内容

- 再起不能状態（doomed）時は「なすがまま」のみ表示するよう修正
- 「もがく」「じっとする」「あばれる」ボタンを再起不能時に非表示に
- BattleScene.tsのupdateActionAvailabilityメソッドを改善

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->