### PR TITLE
🐛 「あばれる」スキル使用時にボスがスタンしない不具合を修正

### DIFF
--- a/src/game/scenes/BattleScene.ts
+++ b/src/game/scenes/BattleScene.ts
@@ -527,6 +527,12 @@ export class BattleScene {
                 this.battleStats.mpSpent += mpCost;
             }
             
+            // Check if this was a successful struggle skill that broke restraint
+            if (skillType === SkillType.Struggle && result.success) {
+                this.boss.onRestraintBroken();
+                this.addBattleLogMessage(`${this.boss.displayName}は反動で動けなくなった！`, 'system', 'boss');
+            }
+            
             // Apply damage if applicable with custom variance
             if (result.damage && result.damage > 0) {
                 const skills = this.player.getAvailableSkills();


### PR DESCRIPTION
- useSkill()メソッドでStruggleスキル成功時にboss.onRestraintBroken()を呼ぶよう修正
- 通常の「もがく」アクションと同様にボスが反動で3ターンスタンするように統一

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- I want to review in Japanese. -->
## 内容

ここにPRの内容を記載してください。

## 動作確認項目

- [x] xxxxxx

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->