### PR TITLE
✨ アクション優先度フラグシステムを実装

### DIFF
--- a/src/game/entities/Player.ts
+++ b/src/game/entities/Player.ts
@@ -1,4 +1,4 @@
-import { StatusEffectType } from '../systems/StatusEffect';
+import { StatusEffectType, ActionPriority } from '../systems/StatusEffect';
 import { AbilitySystem, AbilityType, Equipment, WEAPONS, ARMORS } from '../systems/AbilitySystem';
 import { PlayerSaveManager, PlayerSaveData } from '../systems/PlayerSaveData';
 import { updatePlayerItems } from '../data/ExtendedItems';
@@ -22,6 +22,7 @@ export interface Skill {
     criticalRate?: number; // Custom critical hit rate (0-1)
     damageVarianceMin?: number; // Minimum damage variance percentage (default: -20)
     damageVarianceMax?: number; // Maximum damage variance percentage (default: +20)
+    priority?: ActionPriority; // Action priority level
 }
 
 export interface SkillResult {
@@ -374,6 +375,7 @@ export class Player extends Actor {
                 name: '☠なすがまま',
                 description: '再起不能でもう行動できない',
                 mpCost: 0,
+                priority: ActionPriority.CannotAct,
                 canUse: () => true,
                 use: (player: Player) => {
                     return {
@@ -391,6 +393,7 @@ export class Player extends Actor {
                 name: '😴なすがまま',
                 description: '深い眠りに落ちて行動できない',
                 mpCost: 0,
+                priority: ActionPriority.CannotAct,
                 canUse: () => true,
                 use: (player: Player) => {
                     return {
@@ -407,6 +410,7 @@ export class Player extends Actor {
                 name: 'パワーアタック',
                 description: '2.5倍の攻撃力で確実に攻撃（20MP）',
                 mpCost: 20,
+                priority: ActionPriority.NormalAction,
                 damageVarianceMin: -0.2,
                 damageVarianceMax: 0.5,
                 canUse: (player: Player) => !player.statusEffects.isExhausted() && player.statusEffects.canAct(),
@@ -434,6 +438,7 @@ export class Player extends Actor {
                 name: 'ヒール',
                 description: 'HPを100回復（30MP）',
                 mpCost: 30,
+                priority: ActionPriority.NormalAction,
                 canUse: (player: Player) => !player.statusEffects.isExhausted() && player.statusEffects.canAct() && player.hp < player.maxHp,
                 use: (player: Player) => {
                     const mpInsufficient = !player.consumeMp(30);
@@ -458,6 +463,7 @@ export class Player extends Actor {
                 name: 'あばれる',
                 description: '拘束状態専用：脱出確率2倍（30MP）',
                 mpCost: 30,
+                priority: ActionPriority.StruggleAction,
                 canUse: (player: Player) => !player.statusEffects.isExhausted() && 
                     (player.statusEffects.isRestrained() || player.statusEffects.isEaten()),
                 use: (player: Player) => {

--- a/src/game/systems/StatusEffect.ts
+++ b/src/game/systems/StatusEffect.ts
@@ -1,8 +1,8 @@
-export { StatusEffectType } from './StatusEffectTypes';
+export { StatusEffectType, ActionPriority } from './StatusEffectTypes';
 export type { StatusEffect, StatusEffectConfig } from './StatusEffectTypes';
 
 import { createStatusEffectConfigs } from './status-effects';
-import { StatusEffectType, StatusEffect, StatusEffectConfig } from './StatusEffectTypes';
+import { StatusEffectType, StatusEffect, StatusEffectConfig, ActionPriority } from './StatusEffectTypes';
 
 export class StatusEffectManager {
     private effects: Map<StatusEffectType, StatusEffect> = new Map();
@@ -252,5 +252,22 @@ export class StatusEffectManager {
             }
         }
         return true;
+    }
+    
+    getActionPriority(): ActionPriority {
+        let highestPriority = ActionPriority.NormalAction;
+        
+        for (const [type, _effect] of this.effects) {
+            const config = StatusEffectManager.configs.get(type);
+            const priority = config?.modifiers?.actionPriority;
+            
+            if (priority === ActionPriority.CannotAct) {
+                return ActionPriority.CannotAct;
+            } else if (priority === ActionPriority.StruggleAction && highestPriority === ActionPriority.NormalAction) {
+                highestPriority = ActionPriority.StruggleAction;
+            }
+        }
+        
+        return highestPriority;
     }
 }

--- a/src/game/systems/StatusEffectTypes.ts
+++ b/src/game/systems/StatusEffectTypes.ts
@@ -1,3 +1,9 @@
+export enum ActionPriority {
+    CannotAct = 'cannot-act',
+    StruggleAction = 'struggle-action', 
+    NormalAction = 'normal-action'
+}
+
 export enum StatusEffectType {
     // `Dead` is for Player to make game-over state.
     // NOTE: It's not meaning actual "death".
@@ -85,5 +91,6 @@ export interface StatusEffectConfig {
         struggleRate?: number; // Multiplier for struggle success rate (default: 1.0)
         canAct?: boolean; // Whether the entity can act (default: true)
         canUseSkills?: boolean; // Whether skills can be used (default: true)
+        actionPriority?: ActionPriority; // Action priority level
     };
 }

--- a/src/game/systems/status-effects/core-states.ts
+++ b/src/game/systems/status-effects/core-states.ts
@@ -1,4 +1,4 @@
-import { StatusEffectType, StatusEffectConfig } from '../StatusEffectTypes';
+import { StatusEffectType, StatusEffectConfig, ActionPriority } from '../StatusEffectTypes';
 
 export const coreStatesConfigs: Map<StatusEffectType, StatusEffectConfig> = new Map([
     [StatusEffectType.Dead, {
@@ -9,7 +9,8 @@ export const coreStatesConfigs: Map<StatusEffectType, StatusEffectConfig> = new 
         category: 'neutral',
         isDebuff: false,
         modifiers: {
-            canAct: false
+            canAct: false,
+            actionPriority: ActionPriority.CannotAct
         }
     }],
     [StatusEffectType.Doomed, {
@@ -20,7 +21,8 @@ export const coreStatesConfigs: Map<StatusEffectType, StatusEffectConfig> = new 
         category: 'neutral',
         isDebuff: false,
         modifiers: {
-            canAct: false
+            canAct: false,
+            actionPriority: ActionPriority.CannotAct
         }
     }],
     [StatusEffectType.KnockedOut, {
@@ -31,7 +33,8 @@ export const coreStatesConfigs: Map<StatusEffectType, StatusEffectConfig> = new 
         category: 'debuff',
         isDebuff: true,
         modifiers: {
-            canAct: false
+            canAct: false,
+            actionPriority: ActionPriority.CannotAct
         }
     }],
     [StatusEffectType.Exhausted, {
@@ -55,7 +58,8 @@ export const coreStatesConfigs: Map<StatusEffectType, StatusEffectConfig> = new 
         category: 'debuff',
         isDebuff: true,
         modifiers: {
-            canAct: false
+            canAct: false,
+            actionPriority: ActionPriority.StruggleAction
         }
     }],
     [StatusEffectType.Cocoon, {
@@ -66,7 +70,8 @@ export const coreStatesConfigs: Map<StatusEffectType, StatusEffectConfig> = new 
         category: 'debuff',
         isDebuff: true,
         modifiers: {
-            canAct: false
+            canAct: false,
+            actionPriority: ActionPriority.StruggleAction
         },
         onTick: (target: any, _effect: any) => {
             // Reduce max HP each turn to represent shrinking
@@ -84,7 +89,8 @@ export const coreStatesConfigs: Map<StatusEffectType, StatusEffectConfig> = new 
         category: 'debuff',
         isDebuff: true,
         modifiers: {
-            canAct: false
+            canAct: false,
+            actionPriority: ActionPriority.StruggleAction
         }
     }]
 ]);


### PR DESCRIPTION
## Summary
- ActionPriority enumを追加し、アクション優先度を明示的に管理
- 優先度: 行動不可 > もがく行動 > 通常行動
- StatusEffectConfigとSkillインターフェースに優先度情報を追加

## 変更内容
- StatusEffectTypes.ts: ActionPriority enum追加
- StatusEffectConfig: actionPriorityモディファイアを追加
- StatusEffectManager: getActionPriority()メソッドを追加
- core-states.ts: 各ステータス効果に適切な優先度を設定
- Player.ts: Skillインターフェースに優先度情報を追加

## ステータス効果の優先度設定
- **CannotAct**: Dead, Doomed, KnockedOut
- **StruggleAction**: Restrained, Eaten, Cocoon
- **NormalAction**: PowerAttack, Heal（デフォルト）

## Test plan
- [x] 型チェック実行
- [x] ビルド実行
- [ ] 各ステータス効果での動作確認
- [ ] 優先度システムの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)