### PR TITLE
💄 バトルログUIの改善

### DIFF
--- a/src/game/scenes/BattleScene.ts
+++ b/src/game/scenes/BattleScene.ts
@@ -13,6 +13,7 @@ export class BattleScene {
     private playerTurn: boolean = true;
     private battleEnded: boolean = false;
     private battleLog: HTMLElement | null = null;
+    private currentRound: number = 0;
     
     // Battle statistics for experience calculation
     private battleStats = {
@@ -137,6 +138,7 @@ export class BattleScene {
         };
         
         this.turnCount = 0;
+        this.currentRound = 1;
         this.playerTurn = true;
         this.battleEnded = false;
         
@@ -167,9 +169,10 @@ export class BattleScene {
     private initializeBattle(): void {
         if (!this.boss) return;
         
-        // Clear battle log
+        // Clear battle log and add initial round
         if (this.battleLog) {
-            this.battleLog.innerHTML = '<p class="text-muted">バトル開始！</p>';
+            this.battleLog.innerHTML = '';
+            this.addRoundDivider(1);
         }
         
         // Set boss name
@@ -812,6 +815,12 @@ export class BattleScene {
         // Process round end effects for both player and boss
         this.processRoundEnd();
         
+        // Add round divider every 2 turns (1 player turn + 1 boss turn)
+        if (this.turnCount % 2 === 0) {
+            this.currentRound++;
+            this.addRoundDivider(this.currentRound);
+        }
+        
         // Start player turn
         if (this.player) {
             this.player.startTurn();
@@ -874,22 +883,75 @@ export class BattleScene {
     private addBattleLogMessage(message: string, type: string = '', actor: 'player' | 'boss' | 'system' = 'system'): void {
         if (!this.battleLog) return;
         
-        const messageElement = document.createElement('p');
-        messageElement.textContent = message;
+        // Create message container
+        const messageContainer = document.createElement('div');
+        messageContainer.className = `battle-message ${actor}`;
         
-        if (type) {
-            messageElement.classList.add(type);
+        // Create message content
+        if (actor === 'system') {
+            // System messages are centered without icons
+            const bubble = document.createElement('div');
+            bubble.className = `message-bubble system ${type}`;
+            bubble.textContent = message;
+            messageContainer.appendChild(bubble);
+        } else {
+            // Player and boss messages have icons and bubbles
+            const icon = document.createElement('div');
+            icon.className = `message-icon ${actor}`;
+            
+            // Set icon based on actor
+            if (actor === 'player') {
+                icon.textContent = '🐍'; // Player's eel icon
+            } else if (actor === 'boss') {
+                // Get boss icon from current boss data
+                const bossIcon = this.getBossIcon();
+                icon.textContent = bossIcon;
+            }
+            
+            const bubble = document.createElement('div');
+            bubble.className = `message-bubble ${actor} ${type}`;
+            bubble.textContent = message;
+            
+            if (actor === 'player') {
+                messageContainer.appendChild(icon);
+                messageContainer.appendChild(bubble);
+            } else {
+                messageContainer.appendChild(bubble);
+                messageContainer.appendChild(icon);
+            }
         }
         
-        // Add actor-specific styling
-        if (actor === 'player') {
-            messageElement.classList.add('battle-log-player');
-        } else if (actor === 'boss') {
-            messageElement.classList.add('battle-log-boss');
-        }
-        
-        this.battleLog.appendChild(messageElement);
+        this.battleLog.appendChild(messageContainer);
         this.battleLog.scrollTop = this.battleLog.scrollHeight;
+    }
+    
+    private addRoundDivider(roundNumber: number): void {
+        if (!this.battleLog) return;
+        
+        const divider = document.createElement('div');
+        divider.className = 'battle-round-divider';
+        
+        const label = document.createElement('span');
+        label.className = 'battle-round-label';
+        label.textContent = `ラウンド ${roundNumber}`;
+        
+        divider.appendChild(label);
+        this.battleLog.appendChild(divider);
+        this.battleLog.scrollTop = this.battleLog.scrollHeight;
+    }
+    
+    private getBossIcon(): string {
+        if (!this.boss) return '👹';
+        
+        // Map boss types to icons based on display name
+        const bossIcons: { [key: string]: string } = {
+            '沼のドラゴン': '🐲',
+            '闇のおばけ': '👻',
+            '機械のクモ': '🕷️',
+            '夢魔ちゃん': '😈'
+        };
+        
+        return bossIcons[this.boss.displayName] || '👹';
     }
     
     /**

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -77,14 +77,181 @@ body {
 }
 
 /* Battle Screen Styles */
+#battle-screen {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+#battle-screen .row.h-100 {
+    flex: 1;
+    min-height: 0;
+}
+
 #battle-log {
     font-family: 'Courier New', monospace;
     font-size: 0.95rem;
     line-height: 1.5;
     background-color: var(--battle-log-bg) !important;
     color: var(--log-text) !important;
+    height: calc(100vh - 300px);
+    min-height: 400px;
+    max-height: calc(100vh - 200px);
 }
 
+/* Round divider styles */
+.battle-round-divider {
+    margin: 1rem 0;
+    text-align: center;
+    position: relative;
+}
+
+.battle-round-divider::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, #64748b, transparent);
+}
+
+.battle-round-label {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    background: #374151;
+    color: #94a3b8;
+    font-size: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid #475569;
+    position: relative;
+    z-index: 1;
+}
+
+/* Battle log message container */
+.battle-message {
+    margin: 0.5rem 0;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.battle-message.system {
+    justify-content: center;
+    margin: 0.75rem 0;
+}
+
+.battle-message.player {
+    justify-content: flex-start;
+}
+
+.battle-message.boss {
+    justify-content: flex-end;
+}
+
+/* Message icon */
+.message-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+    margin-top: 0.25rem;
+}
+
+.message-icon.player {
+    background: linear-gradient(135deg, #2563eb, #1e40af);
+    color: white;
+}
+
+.message-icon.boss {
+    background: linear-gradient(135deg, #dc2626, #b91c1c);
+    color: white;
+}
+
+.message-icon.system {
+    background: linear-gradient(135deg, #64748b, #475569);
+    color: white;
+}
+
+/* Message bubble */
+.message-bubble {
+    max-width: 70%;
+    padding: 0.5rem 0.75rem;
+    border-radius: 12px;
+    position: relative;
+    word-wrap: break-word;
+}
+
+.message-bubble.player {
+    background: rgba(37, 99, 235, 0.15);
+    border: 1px solid rgba(37, 99, 235, 0.3);
+    color: #93c5fd;
+    border-bottom-left-radius: 4px;
+}
+
+.message-bubble.player::before {
+    content: '';
+    position: absolute;
+    left: -8px;
+    bottom: 8px;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 8px 8px 0;
+    border-color: transparent rgba(37, 99, 235, 0.3) transparent transparent;
+}
+
+.message-bubble.boss {
+    background: rgba(220, 38, 38, 0.15);
+    border: 1px solid rgba(220, 38, 38, 0.3);
+    color: #fca5a5;
+    border-bottom-right-radius: 4px;
+}
+
+.message-bubble.boss::before {
+    content: '';
+    position: absolute;
+    right: -8px;
+    bottom: 8px;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 0 8px 8px;
+    border-color: transparent transparent rgba(220, 38, 38, 0.3) transparent;
+}
+
+.message-bubble.system {
+    background: rgba(100, 116, 139, 0.15);
+    border: 1px solid rgba(100, 116, 139, 0.3);
+    color: #cbd5e1;
+    text-align: center;
+    border-radius: 8px;
+}
+
+/* Message type styling */
+.message-bubble.damage {
+    background: rgba(239, 68, 68, 0.15) !important;
+    border-color: rgba(239, 68, 68, 0.3) !important;
+    color: #fca5a5 !important;
+}
+
+.message-bubble.heal {
+    background: rgba(34, 197, 94, 0.15) !important;
+    border-color: rgba(34, 197, 94, 0.3) !important;
+    color: #86efac !important;
+}
+
+.message-bubble.status-effect {
+    background: rgba(245, 158, 11, 0.15) !important;
+    border-color: rgba(245, 158, 11, 0.3) !important;
+    color: #fbbf24 !important;
+}
+
+/* Legacy battle log styling (for backwards compatibility) */
 #battle-log p {
     margin: 0.3rem 0;
     padding: 0.4rem 0.7rem;


### PR DESCRIPTION
## Summary
- 画面下部UIの高さを固定し、バトルログの長さによるボタン位置の変動を防止
- ラウンドごとの区切り線とラウンド番号表示を追加
- アイコンと吹き出し形式のバトルログスタイルを導入
- システムメッセージの中央寄せ表示を実装

## 主な変更点
### UIの高さ固定
- `#battle-screen`にFlexboxレイアウトを適用
- `#battle-log`の高さを`calc(100vh - 300px)`で固定
- 最小・最大高さを指定してレスポンシブ対応

### ラウンド区切り線
- 2ターン（プレイヤー+ボス）ごとに区切り線を自動挿入
- 区切り線中央に「ラウンド X」を表示

### アイコンと吹き出しスタイル
- プレイヤー（🐍）とボス（🐲👻🕷️😈）のアイコンを表示
- チャット風の吹き出しデザインを採用
- プレイヤーメッセージは左寄せ、ボスメッセージは右寄せ
- システムメッセージは中央寄せでアイコンなし

### メッセージタイプ別スタイリング
- ダメージ：赤系の色で表示
- 回復：緑系の色で表示  
- 状態異常：黄系の色で表示
- システム：青系の色で表示

## Test plan
- [ ] バトル画面でUIの高さが固定されることを確認
- [ ] ラウンドごとに区切り線が表示されることを確認
- [ ] プレイヤーとボスのメッセージがアイコン付きで表示されることを確認
- [ ] システムメッセージが中央寄せで表示されることを確認
- [ ] メッセージタイプ別の色分けが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)