### PR TITLE
✨ 新ボス「海のクラーケン」を追加

### DIFF
--- a/src/game/data/bosses/sea-kraken.ts
+++ b/src/game/data/bosses/sea-kraken.ts
@@ -1,5 +1,5 @@
 import { BossData, ActionType, BossAction } from '../../entities/Boss';
-import { StatusEffectType } from '../../systems/StatusEffect';
+import { StatusEffectType } from '../../systems/StatusEffectTypes';
 
 const seaKrakenActions: BossAction[] = [
     {

--- a/src/game/data/bosses/sea-kraken.ts
+++ b/src/game/data/bosses/sea-kraken.ts
@@ -1,0 +1,304 @@
+import { BossData, ActionType, BossAction } from '../../entities/Boss';
+import { StatusEffectType } from '../../systems/StatusEffect';
+
+const seaKrakenActions: BossAction[] = [
+    {
+        type: ActionType.Attack,
+        name: '触手ビンタ',
+        description: '太い触手で相手を叩く',
+        damage: 15,
+        weight: 35,
+        playerStateCondition: 'normal'
+    },
+    {
+        type: ActionType.Attack,
+        name: '叩きつけ',
+        description: '触腕を大きく振り上げて叩きつける',
+        damage: 28,
+        weight: 20,
+        hitRate: 0.65,
+        playerStateCondition: 'normal',
+        damageVarianceMin: -0.15,
+        damageVarianceMax: 0.4
+    },
+    {
+        type: ActionType.StatusAttack,
+        name: 'イカスミブレス',
+        description: '前方にイカスミを吐き出し、視界を奪う',
+        damage: 12,
+        hitRate: 0.9,
+        statusEffect: StatusEffectType.VisionImpairment,
+        weight: 25,
+        messages: [
+            '「グゥゥゥ...」',
+            '<USER>が黒いイカスミを吐き出した！',
+            '<TARGET>の視界が阻害される！'
+        ]
+    },
+    {
+        type: ActionType.RestraintAttack,
+        name: '触腕巻き付け',
+        description: '長い触腕で対象を拘束する',
+        messages: [
+            '「グルルル...」',
+            '<USER>の触腕が<TARGET>に巻き付いた！',
+        ],
+        damage: 14,
+        weight: 10,
+        canUse: (_boss, player, _turn) => {
+            return !player.isRestrained() && !player.isEaten() && Math.random() < 0.4;
+        }
+    },
+    {
+        type: ActionType.Attack,
+        name: '触腕吸引',
+        description: '拘束中の獲物を吸盤で吸引し、エネルギーを吸収する',
+        messages: [
+            '「シュゥゥゥ...」',
+            '<USER>の触腕が<TARGET>を強く吸引する！',
+            'エネルギーが吸収されていく...'
+        ],
+        damage: 20,
+        weight: 40,
+        playerStateCondition: 'restrained',
+        healRatio: 0.8
+    },
+    {
+        type: ActionType.StatusAttack,
+        name: 'イカスミ注入',
+        description: '拘束中の獲物にイカスミを注入し、魅了状態にする',
+        messages: [
+            '「ゴポポポ...」',
+            '<USER>が触腕を<TARGET>の口に入れてイカスミを注入した！',
+            '<TARGET>は催眠効果で魅了されてしまう...'
+        ],
+        damage: 8,
+        weight: 30,
+        playerStateCondition: 'restrained',
+        statusEffect: StatusEffectType.Charm
+    }
+];
+
+export const seaKrakenData: BossData = {
+    id: 'sea-kraken',
+    name: 'SeaKraken',
+    displayName: '🦑 海のクラーケン',
+    description: '深海に生息する巨大な紫色のイカ',
+    questNote: `深海に生息する紫色の体と触手を持つ巨大イカが、海岸に現れて生き物をなんでも飲み込んでいる。その強力な吸引力とイカスミの催眠効果で多くの犠牲者を出している。このクラーケンを討伐し、海の平和を取り戻すことがあなたの任務だ。`,
+    maxHp: 350,
+    attackPower: 15,
+    actions: seaKrakenActions,
+    icon: '🦑',
+    personality: [
+        'グルルル...',
+        'シュゥゥゥ...',
+        'ゴポポポ...',
+        'ズルズル...',
+        'グォォォ...',
+        '美味しそうな匂いだ...'
+    ],
+    aiStrategy: (boss, player, turn) => {
+        // Sea Kraken AI Strategy
+
+        // If player is defeated, use special post-defeat actions
+        if (player.isDefeated()) {
+            const postDefeatedActions: BossAction[] = [
+                {
+                    type: ActionType.PostDefeatedAttack,
+                    name: '体内イカスミ漬け',
+                    description: 'エルナルをイカスミ漬けにしながら体力を吸収し続ける',
+                    messages: [
+                        '「ゴポポポ...」',
+                        '<USER>の体内でイカスミが<TARGET>を包み込んでいる...',
+                        '<TARGET>は催眠状態のまま体力を吸収され続ける...'
+                    ],
+                    statusEffect: StatusEffectType.Charm,
+                    weight: 1
+                },
+                {
+                    type: ActionType.PostDefeatedAttack,
+                    name: '胃袋吸盤吸引',
+                    description: '体内の無数の吸盤でエルナルの体力を永遠に吸収し続ける',
+                    messages: [
+                        '「シュゥゥゥ...」',
+                        '<USER>の胃袋の吸盤が<TARGET>を吸引している...',
+                        '<TARGET>のエネルギーが永遠に吸収されていく...'
+                    ],
+                    statusEffect: StatusEffectType.Weakness,
+                    weight: 1
+                }
+            ];
+            return postDefeatedActions[Math.floor(Math.random() * postDefeatedActions.length)];
+        }
+        
+        // If player is eaten, use varied devour actions
+        if (player.isEaten()) {
+            const eatenActions = [
+                {
+                    type: ActionType.DevourAttack,
+                    name: '胃袋吸盤吸引',
+                    description: '体内の獲物のエネルギーを、胃袋にある無数の吸盤で吸収する',
+                    messages: [
+                        '「シュゥゥゥ...」',
+                        '<USER>の胃袋の吸盤が<TARGET>を強く吸引している！'
+                    ],
+                    damage: 30,
+                    maxHpDamage: 8,
+                    weight: 1
+                },
+                {
+                    type: ActionType.DevourAttack,
+                    name: '体内イカスミ漬け',
+                    description: '体内の獲物をイカスミ漬けにして最大体力を吸収する',
+                    messages: [
+                        '「ゴポポポ...」',
+                        '<USER>の体内でイカスミが<TARGET>を包み込む！',
+                        '<TARGET>は催眠状態になってしまった...'
+                    ],
+                    damage: 20,
+                    maxHpDamage: 5,
+                    statusEffect: StatusEffectType.Charm,
+                    weight: 1
+                }
+            ];
+            return eatenActions[Math.floor(Math.random() * eatenActions.length)];
+        }
+        
+        // Strategic actions based on player state
+        if (player.isKnockedOut()) {
+            if (player.isRestrained()) {
+                // Restrained + Knocked Out: 85% chance to eat
+                if (Math.random() < 0.85) {
+                    return {
+                        type: ActionType.EatAttack,
+                        name: '丸呑み',
+                        description: '拘束した獲物を口に押し込み丸呑みする',
+                        messages: [
+                            '「グォォォ！」',
+                            '<USER>が<TARGET>を触腕ごと大きな口に押し込んだ！',
+                            '<TARGET>は体内に飲み込まれてしまった！'
+                        ],
+                        weight: 1
+                    };
+                }
+            } else {
+                // Normal + Knocked Out: 65% chance to restrain, 25% to eat directly
+                const random = Math.random();
+                if (random < 0.65) {
+                    return {
+                        type: ActionType.RestraintAttack,
+                        name: '触腕巻き付け',
+                        description: '対象を触腕で拘束する',
+                        messages: [
+                            '「グルルル...」',
+                            '<USER>の触腕が<TARGET>に巻き付いた！'
+                        ],
+                        weight: 1
+                    };
+                } else if (random < 0.9) {
+                    return {
+                        type: ActionType.EatAttack,
+                        name: '丸呑み',
+                        description: '獲物を丸呑みする',
+                        messages: [
+                            '「グォォォ！」',
+                            '<USER>が大きな口を開け、<TARGET>を丸呑みにする！'
+                        ],
+                        weight: 1
+                    };
+                }
+            }
+        }
+        
+        // Use ink breath more often when player doesn't have vision impairment
+        if (!player.statusEffects.hasEffect(StatusEffectType.VisionImpairment)) {
+            const inkBreath = seaKrakenActions.find(action => action.statusEffect === StatusEffectType.VisionImpairment);
+            if (inkBreath && Math.random() < 0.6) {
+                return inkBreath;
+            }
+        }
+        
+        // Prefer restraint attacks when player has high HP and isn't restrained
+        if (player.getHpPercentage() > 60 && !player.isRestrained()) {
+            const restraintAction = seaKrakenActions.find(action => action.type === ActionType.RestraintAttack);
+            if (restraintAction && Math.random() < 0.3) {
+                return restraintAction;
+            }
+        }
+        
+        // Default to weighted random selection
+        const currentPlayerState = boss.getPlayerState(player);
+        const availableActions = seaKrakenActions.filter(action => {
+            // Check player state condition
+            if (action.playerStateCondition) {
+                if (action.playerStateCondition !== currentPlayerState) {
+                    return false;
+                }
+            }
+            
+            if (action.canUse) {
+                return action.canUse(boss, player, turn);
+            }
+            return true;
+        });
+        
+        const totalWeight = availableActions.reduce((sum, action) => sum + action.weight, 0);
+        let random = Math.random() * totalWeight;
+        
+        for (const action of availableActions) {
+            random -= action.weight;
+            if (random <= 0) {
+                return action;
+            }
+        }
+        
+        return availableActions[0];
+    }
+};
+
+// Add finishing move for doomed player
+seaKrakenData.finishingMove = function() {
+    return [
+        '「グルルル...」',
+        '<USER>は<TARGET>を体内の深くに送り込む！',
+        '<TARGET>はイカスミを注入されながら吸盤で吸収され続け、<USER>の体内でエネルギーを永遠に吸収されることになった...'
+    ];
+};
+
+// Override dialogue for personality
+seaKrakenData.getDialogue = function(situation: 'battle-start' | 'player-restrained' | 'player-eaten' | 'player-escapes' | 'low-hp' | 'victory') {
+    const dialogues: Record<string, string[]> = {
+        'battle-start': [
+            'グルルル...美味しそうな獲物だ',
+            'シュゥゥゥ...深海から上がってきた甲斐があった',
+            'ゴポポポ...新鮮な匂いがする'
+        ],
+        'player-restrained': [
+            'ズルズル...捕らえたぞ',
+            'グルルル...逃がさん',
+            'シュゥゥゥ...おとなしくしろ'
+        ],
+        'player-eaten': [
+            'ゴポポポ...体内は快適だろう',
+            'グルルル...ゆっくり味わうとしよう',
+            'シュゥゥゥ...栄養を吸収させてもらう'
+        ],
+        'player-escapes': [
+            'グォォォ...逃げたか',
+            'ズルズル...次はそうはいかん',
+            'グルルル...なかなかやる'
+        ],
+        'low-hp': [
+            'グォォォ...まだ触腕は動く！',
+            'ズルズル...深海の力を見せてやる',
+            'シュゥゥゥ...これで終わりではない！'
+        ],
+        'victory': [
+            'ゴポポポ...満足だ',
+            'また深海に戻るとしよう'
+        ]
+    };
+    
+    const options = dialogues[situation] || dialogues['battle-start'];
+    return options[Math.floor(Math.random() * options.length)];
+};

--- a/src/game/data/index.ts
+++ b/src/game/data/index.ts
@@ -5,6 +5,7 @@ import { mechSpiderData } from './bosses/mech-spider';
 import { dreamDemonData } from './bosses/dream-demon';
 import { scorpionCarrierData } from './bosses/scorpion-carrier';
 import { mikanDragonData } from './bosses/mikan-dragon';
+import { seaKrakenData } from './bosses/sea-kraken';
 
 export const bosses: Map<string, BossData> = new Map([
     ['swamp-dragon', swampDragonData],
@@ -12,7 +13,8 @@ export const bosses: Map<string, BossData> = new Map([
     ['mech-spider', mechSpiderData],
     ['dream-demon', dreamDemonData],
     ['scorpion-carrier', scorpionCarrierData],
-    ['mikan-dragon', mikanDragonData]
+    ['mikan-dragon', mikanDragonData],
+    ['sea-kraken', seaKrakenData]
 ]);
 
 export function getBossData(id: string): BossData | undefined {
@@ -23,4 +25,4 @@ export function getAllBossData(): BossData[] {
     return Array.from(bosses.values());
 }
 
-export { swampDragonData, darkGhostData, mechSpiderData, dreamDemonData, scorpionCarrierData, mikanDragonData };
+export { swampDragonData, darkGhostData, mechSpiderData, dreamDemonData, scorpionCarrierData, mikanDragonData, seaKrakenData };

--- a/src/game/systems/StatusEffect.ts
+++ b/src/game/systems/StatusEffect.ts
@@ -154,6 +154,19 @@ export class StatusEffectManager {
         return modifier;
     }
     
+    getAccuracyModifier(): number {
+        let modifier = 1.0;
+        
+        for (const [type, _effect] of this.effects) {
+            const config = StatusEffectManager.configs.get(type);
+            if (config?.modifiers?.accuracy !== undefined) {
+                modifier *= config.modifiers.accuracy;
+            }
+        }
+        
+        return modifier;
+    }
+    
     canAct(): boolean {
         for (const [type, _effect] of this.effects) {
             const config = StatusEffectManager.configs.get(type);

--- a/src/game/systems/StatusEffectTypes.ts
+++ b/src/game/systems/StatusEffectTypes.ts
@@ -100,6 +100,7 @@ export interface StatusEffectConfig {
         attackPower?: number; // Multiplier for attack power (default: 1.0)
         damageReceived?: number; // Multiplier for damage received (default: 1.0)
         struggleRate?: number; // Multiplier for struggle success rate (default: 1.0)
+        accuracy?: number; // Multiplier for hit accuracy (default: 1.0)
         canAct?: boolean; // Whether the entity can act (default: true)
         canUseSkills?: boolean; // Whether skills can be used (default: true)
         actionPriority?: ActionPriority; // Action priority level

--- a/src/game/systems/StatusEffectTypes.ts
+++ b/src/game/systems/StatusEffectTypes.ts
@@ -69,7 +69,10 @@ export enum StatusEffectType {
     Weakening = 'weakening',
     
     // Mikan Dragon effects
-    Lethargy = 'lethargy'
+    Lethargy = 'lethargy',
+    
+    // Sea Kraken effects
+    VisionImpairment = 'vision-impairment'
 }
 
 export interface StatusEffect {

--- a/src/game/systems/status-effects/battle-effects.ts
+++ b/src/game/systems/status-effects/battle-effects.ts
@@ -171,5 +171,15 @@ export const battleEffectsConfigs: Map<StatusEffectType, StatusEffectConfig> = n
         modifiers: {
             attackPower: 0.3
         }
+    }],
+    
+    // Sea Kraken status effects
+    [StatusEffectType.VisionImpairment, {
+        type: StatusEffectType.VisionImpairment,
+        name: '視界阻害',
+        description: 'イカスミで視界が阻害され、攻撃の命中率が低下',
+        duration: 3,
+        category: 'debuff',
+        isDebuff: true
     }]
 ]);

--- a/src/game/systems/status-effects/battle-effects.ts
+++ b/src/game/systems/status-effects/battle-effects.ts
@@ -180,6 +180,9 @@ export const battleEffectsConfigs: Map<StatusEffectType, StatusEffectConfig> = n
         description: 'イカスミで視界が阻害され、攻撃の命中率が低下',
         duration: 3,
         category: 'debuff',
-        isDebuff: true
+        isDebuff: true,
+        modifiers: {
+            accuracy: 0.7 // Reduces accuracy to 70% of its original value
+        }
     }]
 ]);

--- a/src/index.html
+++ b/src/index.html
@@ -152,6 +152,16 @@
                                 </div>
                             </div>
                         </div>
+                        
+                        <div class="col-md-4 mb-4">
+                            <div class="card bg-secondary h-100 boss-card" data-boss="sea-kraken">
+                                <div class="card-body text-center">
+                                    <h3 class="card-title">🦑 海のクラーケン</h3>
+                                    <p class="card-text">深海の紫色の巨大イカ。触手の吸引力とイカスミの催眠効果に注意！</p>
+                                    <button class="btn btn-primary w-100">選択</button>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- 新ボス「海のクラーケン」を実装
- 触手による拘束攻撃と吸引によるHP吸収機能を追加
- 新しい状態異常「視界阻害」を実装
- イカスミによる催眠効果付きの攻撃を追加
- 食べられ状態時の特殊攻撃パターンを実装

## 主な機能
### ボス特徴
- 深海に生息する紫色の巨大イカ
- 強力な吸引力を持つ触手と吸盤
- イカスミの催眠効果

### 通常攻撃
- 触手ビンタ：通常攻撃
- 叩きつけ：高威力・低命中率攻撃
- イカスミブレス：視界阻害状態異常付与
- 触腕巻き付け：拘束攻撃
- 触腕吸引：拘束時のHP吸収攻撃
- イカスミ注入：拘束時の魅了攻撃

### 特殊状態時の攻撃
- 食べられ状態時：胃袋吸盤吸引、体内イカスミ漬け
- 再起不能時：永続的なエネルギー吸収

## Test plan
- [x] TypeScript型チェックの通過
- [x] Webpackビルドの成功
- [ ] ボス選択画面でのクラーケン表示確認
- [ ] バトル画面での各攻撃動作確認
- [ ] 視界阻害状態異常の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)