### PR TITLE
💄 最大HP変動時のHPバー表示を改善

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # GitHub Copilot Instructions
 
+use context 7
+
 この指示書は、GitHub
 Copilotがeel-rpg-gameプロジェクトで効果的にコード補完を行うためのガイドラインです。
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -128,3 +128,17 @@ src/
     - 🚚 ファイル・フォルダ整理
     - 🍱 画像や音声などリソース周りの変更
 - Co-Authored-By: Claude記載時はClaude Code使用
+
+## PRテンプレート
+
+[pull_request_template.md](./pull_request_template.md) を参照してください。
+
+## PRレビュー時の指示
+
+- レビューは日本語で行うこと
+- 以下のprefixを使用すること
+  - [must] - 必須の修正
+  - [imo] - 個人的な意見
+  - [nits] - 細かい指摘
+  - [ask] - 質問
+  - [fyi] - 参考情報

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,9 @@
-<!-- I want to review in Japanese. -->
 ## 内容
 
 ここにPRの内容を記載してください。
 
 ## 動作確認項目
 
+ここにPRの動作確認項目を記載してください。
+
 - [x] xxxxxx
-
-<!-- for GitHub Copilot review rule -->
-<!--
-レビューする際には、以下のprefix(接頭辞)をつけてください
-[must]  
-[imo] (in my opinion)  
-[nits](nitpick) 
-[ask]  
-[fyi]
--->
-<!-- for GitHub Copilot review  rule-->
-
-<!-- I want to review in Japanese. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+use context 7
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## 開発コマンド

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,8 @@ Claude Codeは以下の方針に従ってgitコミットを行うこと
 - `bugfix/` + バグ内容
 - `refactor/` + リファクタリング内容
 - `docs/` + ドキュメント更新内容
+
+### PR 作成時の注意点
+
+- PRタイトルと内容は日本語で記述すること
+- テンプレートは `.github/PULL_REQUEST_TEMPLATE.md` を使用

--- a/src/game/entities/Actor.ts
+++ b/src/game/entities/Actor.ts
@@ -156,35 +156,21 @@ export abstract class Actor {
     }
 
     /**
-     * Get HP bar percentage based on initial max HP (for bar width display)
-     * If current max HP is higher than initial, use normal percentage to prevent overflow
+     * Get HP bar percentage based on max HP (for bar width display)
      */
     getHpBarPercentage(): number {
-        if (this.initialMaxHp <= 0) return 0;
+        if (this.maxHp <= 0) return 0;
         
-        // If current max HP is higher than initial, use normal percentage
-        if (this.maxHp > this.initialMaxHp) {
-            return this.getHpPercentage();
-        }
-        
-        // If current max HP is lower or equal, use initial max HP as base
-        return (this.hp / this.initialMaxHp) * 100;
+        return (this.hp / this.maxHp) * 100;
     }
 
     /**
-     * Get MP bar percentage based on initial max MP (for bar width display)
-     * If current max MP is higher than initial, use normal percentage to prevent overflow
+     * Get MP bar percentage based on max MP (for bar width display)
      */
     getMpBarPercentage(): number {
-        if (this.initialMaxMp <= 0) return 0;
-        
-        // If current max MP is higher than initial, use normal percentage
-        if (this.maxMp > this.initialMaxMp) {
-            return this.getMpPercentage();
-        }
-        
-        // If current max MP is lower or equal, use initial max MP as base
-        return (this.mp / this.initialMaxMp) * 100;
+        if (this.maxMp <= 0) return 0;
+
+        return (this.mp / this.maxMp) * 100;
     }
 
     /**

--- a/src/game/entities/Actor.ts
+++ b/src/game/entities/Actor.ts
@@ -157,16 +157,64 @@ export abstract class Actor {
 
     /**
      * Get HP bar percentage based on initial max HP (for bar width display)
+     * If current max HP is higher than initial, use normal percentage to prevent overflow
      */
     getHpBarPercentage(): number {
-        return this.initialMaxHp > 0 ? (this.hp / this.initialMaxHp) * 100 : 0;
+        if (this.initialMaxHp <= 0) return 0;
+        
+        // If current max HP is higher than initial, use normal percentage
+        if (this.maxHp > this.initialMaxHp) {
+            return this.getHpPercentage();
+        }
+        
+        // If current max HP is lower or equal, use initial max HP as base
+        return (this.hp / this.initialMaxHp) * 100;
     }
 
     /**
      * Get MP bar percentage based on initial max MP (for bar width display)
+     * If current max MP is higher than initial, use normal percentage to prevent overflow
      */
     getMpBarPercentage(): number {
-        return this.initialMaxMp > 0 ? (this.mp / this.initialMaxMp) * 100 : 0;
+        if (this.initialMaxMp <= 0) return 0;
+        
+        // If current max MP is higher than initial, use normal percentage
+        if (this.maxMp > this.initialMaxMp) {
+            return this.getMpPercentage();
+        }
+        
+        // If current max MP is lower or equal, use initial max MP as base
+        return (this.mp / this.initialMaxMp) * 100;
+    }
+
+    /**
+     * Get HP progress container width percentage (for container resize)
+     */
+    getHpContainerPercentage(): number {
+        if (this.initialMaxHp <= 0) return 100;
+        
+        // If current max HP is higher than initial, keep container at 100%
+        if (this.maxHp > this.initialMaxHp) {
+            return 100;
+        }
+        
+        // If current max HP is lower, shrink container proportionally
+        return (this.maxHp / this.initialMaxHp) * 100;
+    }
+
+    /**
+     * Get MP progress container width percentage (for container resize)
+     */
+    getMpContainerPercentage(): number {
+        if (this.initialMaxMp <= 0) return 100;
+        
+        // If current max MP is higher than initial, keep container at 100%
+        if (this.maxMp > this.initialMaxMp) {
+            return 100;
+        }
+        
+        // If current max MP is lower, shrink container proportionally
+        return (this.maxMp / this.initialMaxMp) * 100;
     }
 
     /**

--- a/src/game/entities/Actor.ts
+++ b/src/game/entities/Actor.ts
@@ -9,6 +9,10 @@ export abstract class Actor {
     public attackPower: number;
     public defense: number = 0;
     public statusEffects: StatusEffectManager = new StatusEffectManager();
+    
+    // Initial stats at battle start (for UI bar display)
+    public initialMaxHp: number = 0;
+    public initialMaxMp: number = 0;
 
     constructor(displayName: string, maxHp: number, attackPower: number, maxMp: number = 0) {
         this.displayName = displayName;
@@ -152,6 +156,20 @@ export abstract class Actor {
     }
 
     /**
+     * Get HP bar percentage based on initial max HP (for bar width display)
+     */
+    getHpBarPercentage(): number {
+        return this.initialMaxHp > 0 ? (this.hp / this.initialMaxHp) * 100 : 0;
+    }
+
+    /**
+     * Get MP bar percentage based on initial max MP (for bar width display)
+     */
+    getMpBarPercentage(): number {
+        return this.initialMaxMp > 0 ? (this.mp / this.initialMaxMp) * 100 : 0;
+    }
+
+    /**
      * Check if actor is defeated
      */
     isDefeated(): boolean {
@@ -171,6 +189,14 @@ export abstract class Actor {
         // Reset HP and MP to maximum
         this.hp = this.maxHp;
         this.mp = this.maxMp;
+    }
+
+    /**
+     * Save initial stats at battle start for UI bar calculation
+     */
+    saveInitialStats(): void {
+        this.initialMaxHp = this.maxHp;
+        this.initialMaxMp = this.maxMp;
     }
 
     /**

--- a/src/game/scenes/BattleScene.ts
+++ b/src/game/scenes/BattleScene.ts
@@ -221,6 +221,14 @@ export class BattleScene {
         if (this.bossNameElement) {
             this.bossNameElement.textContent = this.boss.displayName;
         }
+        
+        // Save initial stats for HP/MP bar calculation
+        if (this.player) {
+            this.player.saveInitialStats();
+        }
+        if (this.boss) {
+            this.boss.saveInitialStats();
+        }
     }
     
     private updateUI(): void {
@@ -254,14 +262,15 @@ export class BattleScene {
         
         // HP Bar
         if (this.playerHpBar) {
-            const percentage = this.player.getHpPercentage();
-            this.playerHpBar.style.width = `${percentage}%`;
+            const barPercentage = this.player.getHpBarPercentage();
+            const colorPercentage = this.player.getHpPercentage();
+            this.playerHpBar.style.width = `${barPercentage}%`;
             
-            // Change color based on HP
+            // Change color based on HP relative to current max
             this.playerHpBar.className = 'progress-bar';
-            if (percentage > 75) {
+            if (colorPercentage > 75) {
                 this.playerHpBar.classList.add('bg-success');
-            } else if (percentage > 25) {
+            } else if (colorPercentage > 25) {
                 this.playerHpBar.classList.add('bg-warning');
             } else {
                 this.playerHpBar.classList.add('bg-danger');
@@ -274,8 +283,8 @@ export class BattleScene {
         
         // MP Bar
         if (this.playerMpBar) {
-            const mpPercentage = this.player.getMpPercentage();
-            this.playerMpBar.style.width = `${mpPercentage}%`;
+            const mpBarPercentage = this.player.getMpBarPercentage();
+            this.playerMpBar.style.width = `${mpBarPercentage}%`;
         }
         
         // Status Effects
@@ -291,8 +300,8 @@ export class BattleScene {
         
         // HP Bar
         if (this.bossHpBar) {
-            const percentage = this.boss.getHpPercentage();
-            this.bossHpBar.style.width = `${percentage}%`;
+            const barPercentage = this.boss.getHpBarPercentage();
+            this.bossHpBar.style.width = `${barPercentage}%`;
         }
         
         // Status Effects

--- a/src/game/scenes/BattleScene.ts
+++ b/src/game/scenes/BattleScene.ts
@@ -67,15 +67,18 @@ export class BattleScene {
     private playerHpElement: HTMLElement | null = null;
     private playerMaxHpElement: HTMLElement | null = null;
     private playerHpBar: HTMLElement | null = null;
+    private playerHpProgress: HTMLElement | null = null;
     private playerMpElement: HTMLElement | null = null;
     private playerMaxMpElement: HTMLElement | null = null;
     private playerMpBar: HTMLElement | null = null;
+    private playerMpProgress: HTMLElement | null = null;
     private playerStatusEffects: HTMLElement | null = null;
     
     private bossNameElement: HTMLElement | null = null;
     private bossHpElement: HTMLElement | null = null;
     private bossMaxHpElement: HTMLElement | null = null;
     private bossHpBar: HTMLElement | null = null;
+    private bossHpProgress: HTMLElement | null = null;
     private bossStatusEffects: HTMLElement | null = null;
     
     private actionButtons: HTMLElement | null = null;
@@ -100,15 +103,18 @@ export class BattleScene {
         this.playerHpElement = document.getElementById('player-hp');
         this.playerMaxHpElement = document.getElementById('player-max-hp');
         this.playerHpBar = document.getElementById('player-hp-bar');
+        this.playerHpProgress = document.getElementById('player-hp-progress');
         this.playerMpElement = document.getElementById('player-mp');
         this.playerMaxMpElement = document.getElementById('player-max-mp');
         this.playerMpBar = document.getElementById('player-mp-bar');
+        this.playerMpProgress = document.getElementById('player-mp-progress');
         this.playerStatusEffects = document.getElementById('player-status-effects');
         
         this.bossNameElement = document.getElementById('boss-name');
         this.bossHpElement = document.getElementById('boss-hp');
         this.bossMaxHpElement = document.getElementById('boss-max-hp');
         this.bossHpBar = document.getElementById('boss-hp-bar');
+        this.bossHpProgress = document.getElementById('boss-hp-progress');
         this.bossStatusEffects = document.getElementById('boss-status-effects');
         
         this.actionButtons = document.getElementById('action-buttons');
@@ -260,6 +266,12 @@ export class BattleScene {
         if (this.playerHpElement) this.playerHpElement.textContent = this.player.hp.toString();
         if (this.playerMaxHpElement) this.playerMaxHpElement.textContent = this.player.maxHp.toString();
         
+        // HP Progress Container
+        if (this.playerHpProgress) {
+            const containerPercentage = this.player.getHpContainerPercentage();
+            this.playerHpProgress.style.width = `${containerPercentage}%`;
+        }
+        
         // HP Bar
         if (this.playerHpBar) {
             const barPercentage = this.player.getHpBarPercentage();
@@ -281,6 +293,12 @@ export class BattleScene {
         if (this.playerMpElement) this.playerMpElement.textContent = this.player.mp.toString();
         if (this.playerMaxMpElement) this.playerMaxMpElement.textContent = this.player.maxMp.toString();
         
+        // MP Progress Container
+        if (this.playerMpProgress) {
+            const mpContainerPercentage = this.player.getMpContainerPercentage();
+            this.playerMpProgress.style.width = `${mpContainerPercentage}%`;
+        }
+        
         // MP Bar
         if (this.playerMpBar) {
             const mpBarPercentage = this.player.getMpBarPercentage();
@@ -297,6 +315,12 @@ export class BattleScene {
         // HP
         if (this.bossHpElement) this.bossHpElement.textContent = this.boss.hp.toString();
         if (this.bossMaxHpElement) this.bossMaxHpElement.textContent = this.boss.maxHp.toString();
+        
+        // HP Progress Container
+        if (this.bossHpProgress) {
+            const containerPercentage = this.boss.getHpContainerPercentage();
+            this.bossHpProgress.style.width = `${containerPercentage}%`;
+        }
         
         // HP Bar
         if (this.bossHpBar) {

--- a/src/index.html
+++ b/src/index.html
@@ -191,13 +191,13 @@
                                 <div class="card-body">
                                     <div class="mb-2">
                                         ヘルス: <span id="player-hp">1000</span> / <span id="player-max-hp">1000</span>
-                                        <div class="progress">
+                                        <div id="player-hp-progress" class="progress">
                                             <div id="player-hp-bar" class="progress-bar bg-success" style="width: 100%"></div>
                                         </div>
                                     </div>
                                     <div class="mb-2">
                                         マナ: <span id="player-mp">40</span> / <span id="player-max-mp">40</span>
-                                        <div class="progress">
+                                        <div id="player-mp-progress" class="progress">
                                             <div id="player-mp-bar" class="progress-bar bg-info" style="width: 100%"></div>
                                         </div>
                                     </div>
@@ -217,7 +217,7 @@
                                 <div class="card-body">
                                     <div class="mb-2">
                                         ヘルス: <span id="boss-hp">0</span> / <span id="boss-max-hp">0</span>
-                                        <div class="progress">
+                                        <div id="boss-hp-progress" class="progress">
                                             <div id="boss-hp-bar" class="progress-bar bg-danger" style="width: 100%"></div>
                                         </div>
                                     </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -309,6 +309,7 @@ body {
 .progress {
     height: 0.75rem;
     background-color: rgba(255, 255, 255, 0.1);
+    transition: width 0.5s ease;
 }
 
 .progress-bar {


### PR DESCRIPTION
## 内容

プレイヤーの最大HPが変動した際のHPバー表示を改善しました。

### 主な変更内容

1. **最大HP減少時の視覚的改善**
   - HPバーの長さが最大HPに応じて動的に変更されるように
   - プログレスバーコンテナ自体が比例して短縮
   - 最大HPが減った際の「実際に弱くなった」感が分かりやすく

2. **最大HP増加時の安全な処理**
   - 最大HPが初期値より増えた場合は従来通りの100%表示を維持
   - HPバーからのはみ出しを防止

3. **スムーズなアニメーション**
   - バー本体の長さ変動にも0.5秒のイージングアニメーションを追加
   - 既存のprogress-barアニメーションと統一感のあるUI

### 技術的な実装

- **Actor.ts**: 戦闘開始時の初期最大HP・MP保存とバー表示用計算メソッド追加
- **BattleScene.ts**: プログレスコンテナ制御ロジック追加
- **index.html**: プログレスコンテナにID追加
- **main.css**: width transitionアニメーション追加

## 動作確認項目

- [x] TypeScript型チェック正常
- [x] プロダクションビルド正常
- [x] 最大HP減少時にバー本体が短くなることを確認
- [x] 最大HP増加時にバーがはみ出さないことを確認
- [x] アニメーションが滑らかに動作することを確認
- [x] 既存のHP/MPバー機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)