### PR TITLE
✨ ゲストキャラクターの帰属表示機能を追加

### DIFF
--- a/src/game/data/bosses/dream-demon.ts
+++ b/src/game/data/bosses/dream-demon.ts
@@ -518,6 +518,9 @@ export const dreamDemonData: BossData = {
     attackPower: 10,
     actions: dreamDemonActions,
     icon: '😈',
+    guestCharacterInfo: {
+        creator: 'crazybudgie'
+    },
     personality: [
         'あっ、可愛い獲物が来たンメェ〜！',
         'その魂、とっても美味しそうンメェ〜',

--- a/src/game/data/bosses/sea-kraken.ts
+++ b/src/game/data/bosses/sea-kraken.ts
@@ -260,7 +260,7 @@ export const seaKrakenData: BossData = {
 seaKrakenData.finishingMove = function() {
     return [
         '「グルルル...」',
-        '<USER>は<TARGET>を体内の深くに送り込む！',
+        '<USER>の胃袋吸盤が<TARGET>の腕と脚を吸い込み、体全体を吸盤で拘束する！',
         '<TARGET>はイカスミを注入されながら吸盤で吸収され続け、<USER>の体内でエネルギーを永遠に吸収されることになった...'
     ];
 };

--- a/src/game/entities/Boss.ts
+++ b/src/game/entities/Boss.ts
@@ -63,6 +63,10 @@ export interface BossData {
     getDialogue?: (situation: 'battle-start' | 'player-restrained' | 'player-eaten' | 'player-escapes' | 'low-hp' | 'victory') => string;
     finishingMove?: () => string[];
     icon?: string;
+    guestCharacterInfo?: {
+        creator: string;
+        source?: string;
+    };
 }
 
 export class Boss extends Actor {
@@ -76,6 +80,10 @@ export class Boss extends Actor {
     public specialDialogues: Map<string, string> = new Map();
     public finishingMove?: () => string[];
     public icon: string;
+    public guestCharacterInfo?: {
+        creator: string;
+        source?: string;
+    };
     
     constructor(data: BossData) {
         // Boss has unlimited MP (無尽蔵) - set to a high value
@@ -89,6 +97,7 @@ export class Boss extends Actor {
         this.aiStrategy = data.aiStrategy;
         this.finishingMove = data.finishingMove;
         this.icon = data.icon || '👹';
+        this.guestCharacterInfo = data.guestCharacterInfo;
     }
 
     /**

--- a/src/game/scenes/BossSelectScene.ts
+++ b/src/game/scenes/BossSelectScene.ts
@@ -97,6 +97,17 @@ export class BossSelectScene {
                 if (textElement) {
                     textElement.textContent = bossData.description;
                 }
+                
+                // Add guest character attribution if available
+                if (bossData.guestCharacterInfo) {
+                    let attributionElement = card.querySelector('.guest-attribution');
+                    if (!attributionElement) {
+                        attributionElement = document.createElement('div');
+                        attributionElement.className = 'guest-attribution';
+                        card.querySelector('.card-body')?.appendChild(attributionElement);
+                    }
+                    attributionElement.textContent = `Guest Character by ${bossData.guestCharacterInfo.creator}`;
+                }
             }
         });
     }
@@ -149,6 +160,17 @@ export class BossSelectScene {
                     </div>
                 </div>
             `;
+        }
+        
+        // Add guest character attribution if available
+        const modalGuestInfo = document.getElementById('modal-boss-guest-info');
+        if (modalGuestInfo) {
+            if (bossData.guestCharacterInfo) {
+                modalGuestInfo.innerHTML = `<small class="text-muted">Guest Character by ${bossData.guestCharacterInfo.creator}</small>`;
+                modalGuestInfo.classList.remove('d-none');
+            } else {
+                modalGuestInfo.classList.add('d-none');
+            }
         }
     }
     

--- a/src/index.html
+++ b/src/index.html
@@ -341,6 +341,9 @@
                             <!-- Boss stats will be displayed here -->
                         </p>
                         <p id="modal-boss-quest-note">雰囲気ノート</p>
+                        <div id="modal-boss-guest-info" class="d-none">
+                            <!-- Guest character info will be displayed here -->
+                        </div>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -84,6 +84,15 @@ body {
     box-shadow: 0 0 15px rgba(0, 123, 255, 0.5);
 }
 
+/* Guest Character Attribution */
+.guest-attribution {
+    font-size: 0.75rem;
+    color: #6c757d;
+    margin-top: 0.5rem;
+    text-align: center;
+    font-style: italic;
+}
+
 /* Battle Screen Styles */
 #battle-screen {
     height: 100vh;


### PR DESCRIPTION
## 概要
夢魔ちゃん（Dream Demon）がcrazybudgieさんのゲストキャラクターであることを、ボス選択画面で小さく表示する機能を追加しました。

## 変更内容
- **BossDataインターフェース拡張**: `guestCharacterInfo`フィールドを追加
- **夢魔ちゃんのクレジット**: crazybudgieさんのクレジットを追加
- **ボス選択画面の表示**: カードとモーダルの両方に帰属表示を実装
- **CSSスタイリング**: 小さなグレーテキストで目立たない形で表示

## テスト計画
- [x] TypeScriptの型チェックが通ること
- [x] プロダクションビルドが成功すること
- [x] ボス選択画面で夢魔ちゃんのカードに「Guest Character by crazybudgie」と表示されること
- [x] ボス詳細モーダルでも同様に表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)