### PR TITLE
statusChance形式を0.0-1.0に統一

### DIFF
--- a/docs/boss-creation-guide.md
+++ b/docs/boss-creation-guide.md
@@ -67,7 +67,7 @@ interface BossAction {
     canUse?: (boss: Boss, player: Player, turn: number) => boolean;  // 使用条件
     hitRate?: number;               // 命中率（デフォルト: 0.95）
     criticalRate?: number;          // クリティカル率（デフォルト: 0.05）
-    statusChance?: number;          // 状態異常付与確率（デフォルト: 1.0）
+    statusChance?: number;          // 状態異常付与確率（デフォルト: 1.0、範囲: 0.0-1.0）
     playerStateCondition?: string;  // プレイヤー状態条件
     healRatio?: number;             // HP吸収率（0.0-1.0）
     damageVarianceMin?: number;     // ダメージ分散最小値
@@ -267,4 +267,4 @@ aiStrategy: (boss, player, turn) => {
 
 - `StatusEffectType` の定義確認
 - CSS クラスの追加確認
-- `statusChance` の設定確認
+- `statusChance` の設定確認（0.0-1.0の範囲で設定）

--- a/src/game/data/bosses/aqua-serpent.ts
+++ b/src/game/data/bosses/aqua-serpent.ts
@@ -10,7 +10,7 @@ const aquaSerpentActions: BossAction[] = [
         weight: 35,
         playerStateCondition: 'normal',
         statusEffect: StatusEffectType.WaterSoaked,
-        statusChance: 25,
+        statusChance: 0.25,
         hitRate: 0.9
     },
     {
@@ -34,7 +34,7 @@ const aquaSerpentActions: BossAction[] = [
         playerStateCondition: 'normal',
         hitRate: 0.75,
         statusEffect: StatusEffectType.Dizzy,
-        statusChance: 30
+        statusChance: 0.30
     },
     {
         type: ActionType.Attack,
@@ -45,7 +45,7 @@ const aquaSerpentActions: BossAction[] = [
         playerStateCondition: 'normal',
         hitRate: 0.9,
         statusEffect: StatusEffectType.Restrained,
-        statusChance: 80,
+        statusChance: 0.80,
         canUse: (boss, player) => {
             // Only use when HP is below 30% and has cooldown
             return boss.getHpPercentage() <= 30 && 

--- a/src/game/data/bosses/clean-master.ts
+++ b/src/game/data/bosses/clean-master.ts
@@ -15,7 +15,7 @@ const cleanMasterActions: BossAction[] = [
         hitRate: 0.95,
         weight: 25,
         statusEffect: StatusEffectType.Soapy,
-        statusChance: 30,
+        statusChance: 0.30,
         playerStateCondition: 'normal'
     },
     {
@@ -30,7 +30,7 @@ const cleanMasterActions: BossAction[] = [
         hitRate: 0.8,
         weight: 20,
         statusEffect: StatusEffectType.Spinning,
-        statusChance: 25,
+        statusChance: 0.25,
         playerStateCondition: 'normal'
     },
     {
@@ -71,7 +71,7 @@ const cleanMasterActions: BossAction[] = [
         damage: 5,
         hitRate: 0.95,
         statusEffect: StatusEffectType.Soapy,
-        statusChance: 80,
+        statusChance: 0.80,
         weight: 18
     }
 ];
@@ -101,7 +101,7 @@ const cleanMasterActionsRestrained: BossAction[] = [
         damage: 20,
         weight: 25,
         statusEffect: StatusEffectType.Spinning,
-        statusChance: 40
+        statusChance: 0.40
     },
     {
         type: ActionType.Attack,
@@ -114,7 +114,7 @@ const cleanMasterActionsRestrained: BossAction[] = [
         damage: 12,
         weight: 20,
         statusEffect: StatusEffectType.Soapy,
-        statusChance: 60
+        statusChance: 0.60
     }
 ];
 
@@ -131,7 +131,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         damage: 18,
         weight: 25,
         statusEffect: StatusEffectType.Spinning,
-        statusChance: 80
+        statusChance: 0.80
     },
     {
         type: ActionType.DevourAttack,
@@ -144,7 +144,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         damage: 22,
         weight: 20,
         statusEffect: StatusEffectType.Spinning,
-        statusChance: 90
+        statusChance: 0.90
     },
     {
         type: ActionType.DevourAttack,
@@ -157,7 +157,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         damage: 16,
         weight: 25,
         statusEffect: StatusEffectType.Steamy,
-        statusChance: 70
+        statusChance: 0.70
     },
     {
         type: ActionType.DevourAttack,
@@ -170,7 +170,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         damage: 20,
         weight: 15,
         statusEffect: StatusEffectType.Steamy,
-        statusChance: 60
+        statusChance: 0.60
     },
     {
         type: ActionType.DevourAttack,

--- a/src/game/data/bosses/dream-demon.ts
+++ b/src/game/data/bosses/dream-demon.ts
@@ -19,7 +19,7 @@ const dreamDemonActions: BossAction[] = [
         name: '魅惑の眼差し',
         description: '甘い視線で相手を魅了する',
         statusEffect: StatusEffectType.Charm,
-        statusChance: 90,
+        statusChance: 0.90,
         weight: 25,
         messages: ['<USER>は甘い眼差しで<TARGET>を見つめる...', '<TARGET>の心がとろけそうになる...']
     },
@@ -28,7 +28,7 @@ const dreamDemonActions: BossAction[] = [
         name: '麻痺の粉',
         description: '麻痺を誘発する粉末を撒く',
         statusEffect: StatusEffectType.Paralysis,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 20,
         messages: ['<USER>は光る粉を撒き散らした！', '<TARGET>の体がしびれていく...']
     },
@@ -37,7 +37,7 @@ const dreamDemonActions: BossAction[] = [
         name: '淫毒の吐息',
         description: '甘い毒を含んだ息を吹きかける',
         statusEffect: StatusEffectType.AphrodisiacPoison,
-        statusChance: 90,
+        statusChance: 0.90,
         weight: 25,
         messages: ['<USER>は甘い香りの息を<TARGET>に吹きかけた', '<TARGET>の体が熱くなってきた...']
     },
@@ -46,7 +46,7 @@ const dreamDemonActions: BossAction[] = [
         name: 'ねむけ誘発',
         description: '眠気を誘う魔法をかける',
         statusEffect: StatusEffectType.Drowsiness,
-        statusChance: 80,
+        statusChance: 0.80,
         weight: 20,
         messages: ['<USER>は催眠術をかけてきた', '<TARGET>のまぶたが重くなってきた...']
     },
@@ -55,7 +55,7 @@ const dreamDemonActions: BossAction[] = [
         name: '脱力の呪文',
         description: '力を奪う呪文を唱える',
         statusEffect: StatusEffectType.Weakness,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 20,
         messages: ['<USER>は呪文を唱えた', '<TARGET>の力が抜けていく...']
     },
@@ -64,7 +64,7 @@ const dreamDemonActions: BossAction[] = [
         name: 'メロメロビーム',
         description: 'ハート型の光線で相手をメロメロにする',
         statusEffect: StatusEffectType.Infatuation,
-        statusChance: 80,
+        statusChance: 0.80,
         weight: 25,
         messages: ['<USER>はハート型の光線を放った！', '<TARGET>は完全にメロメロになってしまった...']
     },
@@ -73,7 +73,7 @@ const dreamDemonActions: BossAction[] = [
         name: '混乱の渦',
         description: '思考を混乱させる魔法',
         statusEffect: StatusEffectType.Confusion,
-        statusChance: 75,
+        statusChance: 0.75,
         weight: 20,
         messages: ['<USER>は不思議な渦を作り出した', '<TARGET>の思考が混乱してきた...']
     },
@@ -82,7 +82,7 @@ const dreamDemonActions: BossAction[] = [
         name: '発情促進',
         description: '発情状態を誘発する魔法',
         statusEffect: StatusEffectType.Arousal,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 25,
         messages: ['<USER>は妖艶な魔法をかけた', '<TARGET>の体が火照ってきた...']
     },
@@ -91,7 +91,7 @@ const dreamDemonActions: BossAction[] = [
         name: '悩殺ポーズ',
         description: '魅惑的なポーズで相手を悩殺する',
         statusEffect: StatusEffectType.Seduction,
-        statusChance: 80,
+        statusChance: 0.80,
         weight: 20,
         messages: ['<USER>は急接近し深いべろちゅーをしてきた！', '<TARGET>は完全に悩殺されてしまった...']
     },
@@ -100,7 +100,7 @@ const dreamDemonActions: BossAction[] = [
         name: '魔法封印術',
         description: '魔法の使用を封じる',
         statusEffect: StatusEffectType.MagicSeal,
-        statusChance: 90,
+        statusChance: 0.90,
         weight: 15,
         messages: ['<USER>は封印の呪文を唱えた', '<TARGET>の魔力が封じられた！']
     },
@@ -109,7 +109,7 @@ const dreamDemonActions: BossAction[] = [
         name: '快楽の呪い',
         description: '快楽に溺れさせる強力な呪い',
         statusEffect: StatusEffectType.PleasureFall,
-        statusChance: 70,
+        statusChance: 0.70,
         weight: 15,
         messages: ['<USER>は禁断の呪いをかけた...', '<TARGET>は快楽の波に飲み込まれていく...']
     },
@@ -118,7 +118,7 @@ const dreamDemonActions: BossAction[] = [
         name: '淫乱の魔法',
         description: '理性を奪う淫らな魔法',
         statusEffect: StatusEffectType.Lewdness,
-        statusChance: 75,
+        statusChance: 0.75,
         weight: 15,
         messages: ['<USER>は淫らな魔法を唱えた', '<TARGET>の理性が揺らいでいく...']
     },
@@ -127,7 +127,7 @@ const dreamDemonActions: BossAction[] = [
         name: '催眠波動',
         description: '強力な催眠術で意識を奪う',
         statusEffect: StatusEffectType.Hypnosis,
-        statusChance: 60,
+        statusChance: 0.60,
         weight: 10,
         canUse: (_boss, player, _turn) => {
             // Use when player has multiple debuffs
@@ -140,7 +140,7 @@ const dreamDemonActions: BossAction[] = [
         name: '洗脳光線',
         description: '思考を支配する洗脳光線',
         statusEffect: StatusEffectType.Brainwash,
-        statusChance: 50,
+        statusChance: 0.50,
         weight: 8,
         canUse: (_boss, player, _turn) => {
             // Use when player is severely debuffed
@@ -153,7 +153,7 @@ const dreamDemonActions: BossAction[] = [
         name: 'あまあま魔法',
         description: '甘い幸福感で抵抗力を奪う',
         statusEffect: StatusEffectType.Sweet,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 20,
         messages: ['<USER>は甘い魔法をかけた', '<TARGET>は幸せな気分になった...']
     },
@@ -162,7 +162,7 @@ const dreamDemonActions: BossAction[] = [
         name: 'とろとろ魔法',
         description: '意識をとろけさせる魔法',
         statusEffect: StatusEffectType.Melting,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 20,
         messages: ['<USER>はとろける魔法をかけた', '<TARGET>の意識がとろけていく...']
     },
@@ -171,7 +171,7 @@ const dreamDemonActions: BossAction[] = [
         name: 'うっとり魔法',
         description: '恍惚状態にする魔法',
         statusEffect: StatusEffectType.Euphoria,
-        statusChance: 80,
+        statusChance: 0.80,
         weight: 18,
         messages: ['<USER>は恍惚の魔法をかけた', '<TARGET>はうっとりとした表情になった...']
     },
@@ -180,7 +180,7 @@ const dreamDemonActions: BossAction[] = [
         name: '魅惑の術',
         description: '深い魅惑状態にする魔法',
         statusEffect: StatusEffectType.Fascination,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 20,
         messages: ['<USER>は魅惑の術を唱えた', '<TARGET>は深い魅惑に囚われた...']
     },
@@ -189,7 +189,7 @@ const dreamDemonActions: BossAction[] = [
         name: '至福の呪文',
         description: '至福の陶酔状態にする',
         statusEffect: StatusEffectType.Bliss,
-        statusChance: 75,
+        statusChance: 0.75,
         weight: 15,
         messages: ['<USER>は至福の呪文を唱えた', '<TARGET>は至福の表情を浮かべた...']
     },
@@ -198,7 +198,7 @@ const dreamDemonActions: BossAction[] = [
         name: '魅了術',
         description: '強力な魅了魔法で完全支配',
         statusEffect: StatusEffectType.Enchantment,
-        statusChance: 70,
+        statusChance: 0.70,
         weight: 12,
         canUse: (_boss, player, _turn) => {
             // Use when player has multiple debuffs
@@ -249,7 +249,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中の相手に魅惑的なキスをする',
         damage: 1,
         statusEffect: StatusEffectType.Infatuation,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 30,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>に熱いキスをした...', '<TARGET>は完全にとろけてしまった...']
@@ -260,7 +260,7 @@ const dreamDemonActions: BossAction[] = [
         description: '大きな舌で相手をなめまわす',
         damage: 2,
         statusEffect: StatusEffectType.Arousal,
-        statusChance: 90,
+        statusChance: 0.90,
         weight: 28,
         playerStateCondition: 'restrained',
         messages: ['<USER>は大きな舌で<TARGET>をべろべろとなめまわした', '<TARGET>の体が震えている...']
@@ -271,7 +271,7 @@ const dreamDemonActions: BossAction[] = [
         description: '体を密着させて誘惑する',
         damage: 1,
         statusEffect: StatusEffectType.Seduction,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 25,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>に体を密着させてきた', '<TARGET>は誘惑に負けそうになっている...']
@@ -282,7 +282,7 @@ const dreamDemonActions: BossAction[] = [
         description: '体を揺さぶって快楽を与える',
         damage: 2,
         statusEffect: StatusEffectType.PleasureFall,
-        statusChance: 80,
+        statusChance: 0.80,
         weight: 20,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>の体をリズミカルに揺さぶった', '<TARGET>は快楽の波に飲み込まれていく...']
@@ -295,7 +295,7 @@ const dreamDemonActions: BossAction[] = [
         description: '体を激しく密着させて圧迫する',
         damage: 1,
         statusEffect: StatusEffectType.Bliss,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 25,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>に激しく体を押し付けてきた', '<TARGET>は息ができないほど密着されている...']
@@ -306,7 +306,7 @@ const dreamDemonActions: BossAction[] = [
         description: '体を激しく揺さぶって感覚を狂わせる',
         damage: 2,
         statusEffect: StatusEffectType.Lewdness,
-        statusChance: 90,
+        statusChance: 0.90,
         weight: 23,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>を激しく揺さぶった', '<TARGET>の理性が揺らいでいく...']
@@ -317,7 +317,7 @@ const dreamDemonActions: BossAction[] = [
         description: '官能的な動きで相手を魅了する',
         damage: 1,
         statusEffect: StatusEffectType.Fascination,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 26,
         playerStateCondition: 'restrained',
         messages: ['<USER>は官能的な動きを見せつけてきた', '<TARGET>は目が離せなくなっている...']
@@ -328,7 +328,7 @@ const dreamDemonActions: BossAction[] = [
         description: '激しく愛撫して感覚を麻痺させる',
         damage: 2,
         statusEffect: StatusEffectType.Melting,
-        statusChance: 88,
+        statusChance: 0.88,
         weight: 24,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>を激しく愛撫してきた', '<TARGET>の感覚がとろけていく...']
@@ -339,7 +339,7 @@ const dreamDemonActions: BossAction[] = [
         description: '体重をかけて圧迫し続ける',
         damage: 1,
         statusEffect: StatusEffectType.Euphoria,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 22,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>に全体重をかけて圧迫してきた', '<TARGET>は恍惚の表情を浮かべている...']
@@ -352,7 +352,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に強力な魅了をかける',
         damage: 1,
         statusEffect: StatusEffectType.Charm,
-        statusChance: 98,
+        statusChance: 0.98,
         weight: 20,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>を見つめながら強力な魅了をかけた', '<TARGET>の意思が完全に奪われていく...']
@@ -363,7 +363,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に麻痺効果を与える',
         damage: 1,
         statusEffect: StatusEffectType.Paralysis,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 18,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>の神経を痺れさせた', '<TARGET>の体が完全に痺れてしまった...']
@@ -374,7 +374,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に淫毒を注入する',
         damage: 2,
         statusEffect: StatusEffectType.AphrodisiacPoison,
-        statusChance: 98,
+        statusChance: 0.98,
         weight: 22,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>に直接淫毒を注入した', '<TARGET>の体が激しく火照っていく...']
@@ -385,7 +385,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に強制的に眠らせる',
         damage: 1,
         statusEffect: StatusEffectType.Drowsiness,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 19,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>の意識を朦朧とさせた', '<TARGET>の意識がだんだん遠のいていく...']
@@ -396,7 +396,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に力を完全に奪う',
         damage: 1,
         statusEffect: StatusEffectType.Weakness,
-        statusChance: 98,
+        statusChance: 0.98,
         weight: 21,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>の力を吸い取った', '<TARGET>の体から力が完全に抜けていく...']
@@ -407,7 +407,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に思考を混乱させる',
         damage: 1,
         statusEffect: StatusEffectType.Confusion,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 18,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>の思考を混乱させた', '<TARGET>は何が何だかわからなくなっている...']
@@ -418,7 +418,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に魔法を完全封印する',
         damage: 1,
         statusEffect: StatusEffectType.MagicSeal,
-        statusChance: 98,
+        statusChance: 0.98,
         weight: 17,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>の魔力を封印した', '<TARGET>の魔法が使えなくなった...']
@@ -429,7 +429,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に意識をとろけさせる',
         damage: 2,
         statusEffect: StatusEffectType.Melting,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 22,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>の意識をとろけさせた', '<TARGET>の思考が液体のようにとろけていく...']
@@ -440,7 +440,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に恍惚状態にする',
         damage: 1,
         statusEffect: StatusEffectType.Euphoria,
-        statusChance: 92,
+        statusChance: 0.92,
         weight: 19,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>を恍惚状態にした', '<TARGET>はうっとりと夢見心地になっている...']
@@ -451,7 +451,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に甘い幸福感を与える',
         damage: 1,
         statusEffect: StatusEffectType.Sweet,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 20,
         playerStateCondition: 'restrained',
         messages: ['<USER>は<TARGET>に甘い幸福感を与えた', '<TARGET>は幸せそうな表情を浮かべている...']
@@ -462,7 +462,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に強制催眠をかける',
         damage: 1,
         statusEffect: StatusEffectType.Hypnosis,
-        statusChance: 90,
+        statusChance: 0.90,
         weight: 15,
         playerStateCondition: 'restrained',
         canUse: (_boss, player, _turn) => {
@@ -476,7 +476,7 @@ const dreamDemonActions: BossAction[] = [
         description: '拘束中に思考を洗脳する',
         damage: 2,
         statusEffect: StatusEffectType.Brainwash,
-        statusChance: 85,
+        statusChance: 0.85,
         weight: 12,
         playerStateCondition: 'restrained',
         canUse: (_boss, player, _turn) => {
@@ -491,7 +491,7 @@ const dreamDemonActions: BossAction[] = [
         name: '眠りのキス',
         description: '拘束中の相手に眠りを誘うキスをする',
         statusEffect: StatusEffectType.Sleep,
-        statusChance: 95,
+        statusChance: 0.95,
         weight: 5,
         playerStateCondition: 'restrained',
         canUse: (_boss, player, _turn) => {

--- a/src/game/data/bosses/mech-spider.ts
+++ b/src/game/data/bosses/mech-spider.ts
@@ -30,7 +30,7 @@ const mechSpiderActions: BossAction[] = [
         messages: ['<USER>は<TARGET>に噛みついて電気ショックを流す！'],
         damage: 10,
         statusEffect: StatusEffectType.Stunned,
-        statusChance: 30,
+        statusChance: 0.30,
         hitRate: 0.7,
         weight: 12,
         canUse: (_boss, player, _turn) => {
@@ -79,7 +79,7 @@ const mechSpiderActionsRestrained: BossAction[] = [
         messages: ['<USER>は<TARGET>に噛みついて電気ショックを流す！'],
         damage: 10,
         statusEffect: StatusEffectType.Stunned,
-        statusChance: 50,
+        statusChance: 0.50,
         hitRate: 0.95,
         weight: 15
     },

--- a/src/game/data/bosses/scorpion-carrier.ts
+++ b/src/game/data/bosses/scorpion-carrier.ts
@@ -38,7 +38,7 @@ const scorpionCarrierActions: BossAction[] = [
         messages: ['<USER>は尻尾の注射器で<TARGET>に麻酔を注入しようとする！'],
         damage: 8,
         statusEffect: StatusEffectType.Anesthesia,
-        statusChance: 70,
+        statusChance: 0.70,
         hitRate: 0.7,
         weight: 12,
         canUse: (_boss, player, _turn) => {
@@ -67,7 +67,7 @@ const scorpionCarrierActionsRestrained: BossAction[] = [
         messages: ['<USER>は拘束した<TARGET>に猛毒を注射する！'],
         damage: 15,
         statusEffect: StatusEffectType.ScorpionPoison,
-        statusChance: 90,
+        statusChance: 0.90,
         hitRate: 0.95,
         weight: 30
     },
@@ -116,7 +116,7 @@ const scorpionCarrierActionsEaten: BossAction[] = [
         messages: ['<USER>は体内の注射器で<TARGET>に脱力剤を注入する！'],
         damage: 8,
         statusEffect: StatusEffectType.Weakening,
-        statusChance: 80,
+        statusChance: 0.80,
         hitRate: 0.9,
         weight: 25,
         playerStateCondition: 'eaten'

--- a/src/game/entities/Boss.ts
+++ b/src/game/entities/Boss.ts
@@ -43,7 +43,7 @@ export interface BossAction {
     onUse?: (boss: Boss, player: Player) => string[]; // Custom action callback
     hitRate?: number; // Attack hit rate (default: 95%)
     criticalRate?: number; // Critical hit rate (default: 5%)
-    statusChance?: number; // Status effect application chance (default: 100%)
+    statusChance?: number; // Status effect application chance (default: 1.0, range: 0.0-1.0)
     playerStateCondition?: 'normal' | 'ko' | 'restrained' | 'cocoon' | 'eaten' | 'defeated'; // Required player state
     healRatio?: number; // HP absorption ratio from damage dealt (0.0 = no healing, 1.0 = 100% healing)
     damageVarianceMin?: number; // Minimum damage variance percentage (default: -20)
@@ -294,7 +294,7 @@ export class Boss extends Actor {
                     }
                     
                     if (!isMiss && action.statusEffect) {
-                        const statusChance = action.statusChance !== undefined ? action.statusChance / 100 : 1.0;
+                        const statusChance = action.statusChance !== undefined ? action.statusChance : 1.0;
                         if (Math.random() < statusChance) {
                             player.statusEffects.addEffect(action.statusEffect);
                             messages.push(`${player.name}が${this.getStatusEffectName(action.statusEffect)}状態になった！`);
@@ -406,7 +406,7 @@ export class Boss extends Actor {
                     }
 
                     if (action.statusEffect) {
-                        const statusChance = action.statusChance !== undefined ? action.statusChance / 100 : 1.0;
+                        const statusChance = action.statusChance !== undefined ? action.statusChance : 1.0;
                         if (Math.random() < statusChance) {
                             player.statusEffects.addEffect(action.statusEffect);
                             messages.push(`${player.name}が${this.getStatusEffectName(action.statusEffect)}状態になった！`);


### PR DESCRIPTION
## 概要
statusChanceパラメータをパーセンテージ形式（0-100）から小数点形式（0.0-1.0）に統一し、他の確率パラメータと一貫性を保つように修正しました。

## 変更内容
- **Boss.ts**: statusChanceの処理を更新（`/100`の変換処理を削除）
- **ボスデータファイル**: 全てのstatusChance値を小数点形式に変更
  - aqua-serpent.ts: 3箇所
  - clean-master.ts: 9箇所  
  - dream-demon.ts: 42箇所
  - mech-spider.ts: 2箇所
  - scorpion-carrier.ts: 3箇所
- **ドキュメント**: boss-creation-guide.mdでstatusChanceの範囲を明記

## テスト結果
- ✅ TypeScriptタイプチェック成功
- ✅ プロダクションビルド成功

## 利点
- 他の確率パラメータ（hitRate、criticalRateなど）との一貫性向上
- 不要な除算処理の削除によるパフォーマンス向上
- より直感的で分かりやすいAPI

🤖 Generated with [Claude Code](https://claude.ai/code)