### PR TITLE
✨ ボス固有のカスタム変数システムを実装

### DIFF
--- a/src/game/entities/Boss.ts
+++ b/src/game/entities/Boss.ts
@@ -68,6 +68,17 @@ export interface BossData {
         creator: string;
         source?: string;
     };
+    /**
+     * ボス固有のカスタム変数
+     * AI戦略で使用する状態管理や行動制御のための変数を定義
+     * @example
+     * {
+     *   fireBreathCooldown: 0,    // 火のブレス攻撃のクールダウン
+     *   aggressionLevel: 1,       // 攻撃性レベル（1-3）
+     *   enrageThreshold: 30,      // 怒り状態発動のHP閾値
+     *   specialMoveUsed: false    // 特殊技使用フラグ
+     * }
+     */
     customVariables?: Record<string, any>;
 }
 
@@ -88,6 +99,11 @@ export class Boss extends Actor {
     };
     public hasUsedSpecialMove: boolean = false;
     public specialMoveCooldown: number = 0;
+    /**
+     * ボス固有のカスタム変数
+     * AI戦略での状態管理、クールダウン管理、行動制御などに使用
+     * ボスデータの初期値をコピーして初期化される
+     */
     public customVariables: Record<string, any> = {};
     
     constructor(data: BossData) {
@@ -171,10 +187,23 @@ export class Boss extends Actor {
 
     /**
      * 数値型カスタム変数を増減する
+     * 既存の値が数値でない場合はTypeErrorを投げる
+     * 変数が存在しない場合は0として扱う
+     * @param key 変数名
+     * @param delta 増減値
+     * @returns 変更後の値
+     * @throws {TypeError} 既存の値が数値型でない場合
      */
     modifyCustomVariable(key: string, delta: number): number {
-        const currentValue = this.getCustomVariable<number>(key) || 0;
-        const newValue = currentValue + delta;
+        const currentValue = this.getCustomVariable(key);
+        
+        // 変数が存在する場合は型チェック
+        if (currentValue !== undefined && typeof currentValue !== 'number') {
+            throw new TypeError(`Cannot modify custom variable '${key}': existing value is not a number (current type: ${typeof currentValue})`);
+        }
+        
+        const numericValue = currentValue ?? 0;
+        const newValue = numericValue + delta;
         this.setCustomVariable(key, newValue);
         return newValue;
     }

--- a/src/game/entities/Boss.ts
+++ b/src/game/entities/Boss.ts
@@ -68,6 +68,7 @@ export interface BossData {
         creator: string;
         source?: string;
     };
+    customVariables?: Record<string, any>;
 }
 
 export class Boss extends Actor {
@@ -87,6 +88,7 @@ export class Boss extends Actor {
     };
     public hasUsedSpecialMove: boolean = false;
     public specialMoveCooldown: number = 0;
+    public customVariables: Record<string, any> = {};
     
     constructor(data: BossData) {
         // Boss has unlimited MP (無尽蔵) - set to a high value
@@ -101,6 +103,7 @@ export class Boss extends Actor {
         this.finishingMove = data.finishingMove;
         this.icon = data.icon || '👹';
         this.guestCharacterInfo = data.guestCharacterInfo;
+        this.customVariables = data.customVariables ? { ...data.customVariables } : {};
     }
 
     /**
@@ -136,6 +139,58 @@ export class Boss extends Actor {
         
         const healAmount = Math.floor(damage * ratio);
         return this.heal(healAmount);
+    }
+
+    /**
+     * カスタム変数を取得する
+     */
+    getCustomVariable<T = any>(key: string): T | undefined {
+        return this.customVariables[key] as T;
+    }
+
+    /**
+     * カスタム変数を設定する
+     */
+    setCustomVariable<T = any>(key: string, value: T): void {
+        this.customVariables[key] = value;
+    }
+
+    /**
+     * カスタム変数が存在するかチェック
+     */
+    hasCustomVariable(key: string): boolean {
+        return key in this.customVariables;
+    }
+
+    /**
+     * カスタム変数を削除する
+     */
+    removeCustomVariable(key: string): void {
+        delete this.customVariables[key];
+    }
+
+    /**
+     * 数値型カスタム変数を増減する
+     */
+    modifyCustomVariable(key: string, delta: number): number {
+        const currentValue = this.getCustomVariable<number>(key) || 0;
+        const newValue = currentValue + delta;
+        this.setCustomVariable(key, newValue);
+        return newValue;
+    }
+
+    /**
+     * 全てのカスタム変数を取得
+     */
+    getAllCustomVariables(): Record<string, any> {
+        return { ...this.customVariables };
+    }
+
+    /**
+     * カスタム変数をリセット
+     */
+    resetCustomVariables(): void {
+        this.customVariables = {};
     }
     
     


### PR DESCRIPTION
## Summary

ボス固有の変数を管理できるカスタム変数システムを実装しました。

- BossDataインターフェースにcustomVariablesフィールドを追加
- Bossクラスに以下のカスタム変数操作メソッドを実装：
  - getCustomVariable<T>() - 型安全な変数取得
  - setCustomVariable<T>() - 変数の設定
  - hasCustomVariable() - 変数の存在チェック
  - removeCustomVariable() - 変数の削除
  - modifyCustomVariable() - 数値型変数の増減
  - getAllCustomVariables() - 全変数の取得
  - resetCustomVariables() - 変数のリセット

## 実装例

沼のドラゴンでカスタム変数を使用した実例を追加：

- **fireBreathCooldown**: 火のブレス攻撃のクールダウン管理（3ターン）
- **aggressionLevel**: 体力に応じた攻撃性レベル調整（1-3）
- **restraintAttempts**: 拘束攻撃の試行回数記録
- **hasUsedFinisher**: フィニッシャー使用フラグ

これにより、ボスのAI戦略でより複雑で動的な行動パターンを実装できるようになりました。

## Test plan

- [x] TypeScript型チェック通過
- [x] ビルド成功
- [x] カスタム変数の基本操作が正常に動作
- [x] 沼のドラゴンでの実装例が正常に動作

🤖 Generated with Claude Code