### PR TITLE
✨ BossActionにdamageFormulaを追加

### DIFF
--- a/src/game/data/bosses/swamp-dragon.ts
+++ b/src/game/data/bosses/swamp-dragon.ts
@@ -14,7 +14,7 @@ const swampDragonActions: BossAction[] = [
         type: ActionType.Attack,
         name: '噛みつき',
         description: '強力な顎で噛みつく',
-        damage: 30,
+        damageFormula: (actor) => Math.floor(actor.attackPower * 1.5),
         weight: 25,
         hitRate: 0.7,
         criticalRate: 0.08,
@@ -26,7 +26,7 @@ const swampDragonActions: BossAction[] = [
         type: ActionType.StatusAttack,
         name: '炎のブレス',
         description: '灼熱の炎を吐く',
-        damage: 24,
+        damageFormula: (actor) => Math.floor(actor.attackPower * 1.3),
         hitRate: 0.9,
         statusEffect: StatusEffectType.Fire,
         weight: 25


### PR DESCRIPTION
## 概要

BossActionの`damage`による直接値指定の代わりに、`damageFormula`でボス攻撃力を参照できるようにしました。

## 変更内容

- **BossActionインターフェース**: `damageFormula?: (actor: Actor) => number` プロパティを追加
- **ダメージ計算ロジック**: 全ActionTypeでdamageFormulaに対応
  - `ActionType.Attack`
  - `ActionType.StatusAttack` 
  - `ActionType.CocoonAction`
  - `ActionType.DevourAttack`
- **既存互換性**: `damage`プロパティとの併用可能、`damageFormula`が優先
- **実装例**: 沼のドラゴンで使用例を追加

## 使用例

```typescript
{
    type: ActionType.Attack,
    name: '噛みつき',
    description: '強力な顎で噛みつく',
    damageFormula: (actor) => Math.floor(actor.attackPower * 1.5), // 攻撃力の1.5倍
    weight: 25
}
```

## テスト計画

- [x] TypeScript型チェック通過
- [x] ビルド成功
- [x] 既存の`damage`プロパティとの互換性確認
- [x] 沼のドラゴンでの動作例実装

🤖 Generated with [Claude Code](https://claude.ai/code)