### PR TITLE
✨ 闇のおばけの食べられ時行動パターンを拡張

### DIFF
--- a/src/game/data/bosses/dark-ghost.ts
+++ b/src/game/data/bosses/dark-ghost.ts
@@ -156,19 +156,86 @@ export const darkGhostData: BossData = {
             return postDefeatedActions[Math.floor(Math.random() * postDefeatedActions.length)];
         }
         
-        // If player is eaten, devour them
+        // If player is eaten, use various psychological attacks to weaken soul resistance
         if (player.isEaten()) {
-            return {
-                type: ActionType.DevourAttack,
-                name: '魂の捕食',
-                damage: 18,
-                description: '体内にいる獲物の生命エネルギーを吸収する',
-                messages: [
-                    '「キミのタマシイ、おいしいネ...」',
-                    '<USER>は<TARGET>の魂からエネルギーを吸い取っている...'
-                ],
-                weight: 1
-            };
+            const eatenActions: BossAction[] = [
+                {
+                    type: ActionType.DevourAttack,
+                    name: '魂の捕食',
+                    damage: 18,
+                    description: '体内にいる獲物の生命エネルギーを吸収する',
+                    messages: [
+                        '「キミのタマシイ、おいしいネ...」',
+                        '<USER>は<TARGET>の魂からエネルギーを吸い取っている...'
+                    ],
+                    weight: 30
+                },
+                {
+                    type: ActionType.DevourAttack,
+                    name: '恐怖の注入',
+                    damage: 12,
+                    description: '恐怖を心に注ぎ込み魂の抵抗力を削ぐ',
+                    messages: [
+                        '「怖がれば怖がるほど美味しくなるヨ...」',
+                        '<USER>は<TARGET>の心に恐怖を注ぎ込んでいる...',
+                        '<TARGET>は得体の知れない恐怖に包まれた！'
+                    ],
+                    statusEffect: StatusEffectType.Paralysis,
+                    weight: 25
+                },
+                {
+                    type: ActionType.DevourAttack,
+                    name: '絶望の囁き',
+                    damage: 10,
+                    description: '絶望的な言葉で心を折り魂を弱らせる',
+                    messages: [
+                        '「もう誰も助けに来ないヨ...」',
+                        '<USER>が<TARGET>の心に絶望を囁いている...',
+                        '<TARGET>は深い絶望に沈んでいく...'
+                    ],
+                    statusEffect: StatusEffectType.Exhausted,
+                    weight: 20
+                },
+                {
+                    type: ActionType.DevourAttack,
+                    name: '記憶の侵食',
+                    damage: 8,
+                    description: '大切な記憶を蝕み精神的支柱を奪う',
+                    messages: [
+                        '「大切な記憶、消してあげるネ...」',
+                        '<USER>が<TARGET>の記憶を侵食している...',
+                        '<TARGET>の大切な思い出が薄れていく...'
+                    ],
+                    statusEffect: StatusEffectType.Charm,
+                    weight: 15
+                },
+                {
+                    type: ActionType.DevourAttack,
+                    name: '悪夢の投影',
+                    damage: 14,
+                    description: '最悪の悪夢を見せて精神を混乱させる',
+                    messages: [
+                        '「キミの一番嫌な夢を見せてあげるヨ...」',
+                        '<USER>が<TARGET>に悪夢を投影している...',
+                        '<TARGET>は恐ろしい悪夢に囚われた！'
+                    ],
+                    statusEffect: StatusEffectType.Poison,
+                    weight: 10
+                }
+            ];
+            
+            // Weighted random selection from eaten actions
+            const totalWeight = eatenActions.reduce((sum, action) => sum + action.weight, 0);
+            let random = Math.random() * totalWeight;
+            
+            for (const action of eatenActions) {
+                random -= action.weight;
+                if (random <= 0) {
+                    return action;
+                }
+            }
+            
+            return eatenActions[0];
         }
         
         // Strategic actions based on player state


### PR DESCRIPTION
## 概要
闇のおばけの食べられ時行動パターンを単一の「魂の捕食」から5つのバリエーションに拡張しました。

## 実装内容

### 追加された精神攻撃系行動パターン
1. **魂の捕食** (30%) - 従来の行動、最高ダメージ18
2. **恐怖の注入** (25%) - 恐怖で魂の抵抗力を削ぐ、麻痺付与
3. **絶望の囁き** (20%) - 絶望で精神的支柱を破壊、疲労付与  
4. **記憶の侵食** (15%) - 大切な記憶を奪う、魅了付与
5. **悪夢の投影** (10%) - 恐ろしい悪夢で混乱、毒付与

### 設計思想
- 魂を吸い上げやすくするため、主人公を精神的に弱らせる戦略
- 重み付き確率による行動選択で適度なランダム性を保持
- 各行動に状態異常を付与し、段階的に抵抗力を削ぐ仕組み
- 他のボスの物理的な消化促進と同様のコンセプト

## テスト計画
- [ ] 闇のおばけ戦で主人公が食べられ状態になった際の行動確認
- [ ] 各精神攻撃の状態異常効果とメッセージ表示確認
- [ ] 重み付き確率による行動選択の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)