### PR TITLE
夢魔ちゃんのセリフ設定・修正

### DIFF
--- a/src/game/data/bosses/dream-demon.ts
+++ b/src/game/data/bosses/dream-demon.ts
@@ -952,6 +952,7 @@ export const dreamDemonData: BossData = {
                     damageFormula: (user: Boss) => user.attackPower * 0.7,
                     description: '夢の中で魔力を注入しながら生気を吸い取る',
                     messages: [
+                        'ずぶずぶ〜♪ 魔力を直接注入しちゃうンメェ〜',
                         '<USER>は夢の中で<TARGET>に直接魔力を注入した',
                         '<USER>の魔力は<TARGET>の生気を内側から吸い取っている...',
                         '<TARGET>は魔力に侵食されながら生気を内側から奪われていく...'
@@ -965,6 +966,7 @@ export const dreamDemonData: BossData = {
                     damageFormula: (user: Boss) => user.attackPower * 0.5,
                     description: '夢の中で甘い誘惑をしながら生気を吸い取る',
                     messages: [
+                        'あまあま〜♪ 甘い言葉でおびき寄せちゃうンメェ〜',
                         '<USER>は夢の中で<TARGET>に甘い誘惑をささやいた',
                         '<USER>は甘い言葉で<TARGET>の生気をそっと吸い取っている...',
                         '<TARGET>は甘い誘惑に溺れながら生気を静かに奪われている...'
@@ -978,6 +980,7 @@ export const dreamDemonData: BossData = {
                     damageFormula: (user: Boss) => user.attackPower * 0.6,
                     description: '夢の中で完全に支配しながら生気を吸い取る',
                     messages: [
+                        'もう完全にあたいのものンメェ〜♪ 支配しちゃったンメェ〜',
                         '<USER>は夢の中で<TARGET>を完全に支配した',
                         '<USER>は支配した<TARGET>の生気を容赦なく吸い取っている...',
                         '<TARGET>は完全に支配されながら生気を全て奪われていく！'


### PR DESCRIPTION
## Summary

- 夢魔ちゃんに戦闘開始・プレイヤー勝利演出メッセージを追加
- 夢魔ちゃんの各種行動メッセージにセリフを追加
- docs/bosses/dream-demon.mdの設定に基づいた毒舌メスガキ系キャラクターを実装

## 変更内容

### 戦闘開始・勝利演出メッセージ
- clean-masterを参考にした戦闘開始演出メッセージを追加
- 負けず嫌いで言い訳をする性格を反映した勝利時メッセージを追加

### 各種行動メッセージのセリフ追加
- 基本攻撃、状態異常攻撃、拘束攻撃のすべてにセリフを追加
- 夢魔ちゃん特有の口調「ンメェ」を一貫して使用
- 調子乗り・可愛らしさ・ドジっ子要素を適切に表現

### キャラクター設定の反映
- 一人称「あたい」の使用
- 毒舌メスガキ系の性格表現
- 感情の波乱万丈な起伏を表現する多様な感嘆詞

## Test plan

- [x] ゲーム内で夢魔ちゃんとの戦闘をテスト
- [x] 戦闘開始演出が正常に表示されることを確認
- [x] 各種攻撃時にセリフが適切に表示されることを確認
- [x] プレイヤー勝利時の演出が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)