### PR TITLE
ボス選択画面に勝利・敗北状態表示バッジを追加

### DIFF
--- a/src/game/entities/Player.ts
+++ b/src/game/entities/Player.ts
@@ -461,7 +461,7 @@ export class Player extends Actor {
         if (this.isDefeated()) {
             return [{
                 type: SkillType.SubmitToFate,
-                name: '☠なすがまま',
+                name: '💀なすがまま',
                 description: '......',
                 mpCost: 0,
                 priority: ActionPriority.CannotAct,
@@ -479,7 +479,7 @@ export class Player extends Actor {
         if (this.statusEffects.isDoomed()) {
             return [{
                 type: SkillType.GiveUp,
-                name: '☠なすがまま',
+                name: '💀なすがまま',
                 description: '再起不能でもう行動できない',
                 mpCost: 0,
                 priority: ActionPriority.CannotAct,

--- a/src/game/scenes/BossSelectScene.ts
+++ b/src/game/scenes/BossSelectScene.ts
@@ -136,46 +136,38 @@ export class BossSelectScene {
     }
     
     /**
-     * Update boss status badge based on battle history
+     * Update boss status badges based on battle history
      */
     private updateBossStatusBadge(bossId: string, memorialData: MemorialSaveData): void {
-        const badgeElement = document.getElementById(`boss-status-${bossId}`);
-        if (!badgeElement) return;
+        const victoryBadge = document.getElementById(`boss-status-victory-${bossId}`);
+        const defeatBadge = document.getElementById(`boss-status-defeat-${bossId}`);
+        
+        if (!victoryBadge || !defeatBadge) return;
         
         // Find boss memorial record
         const memorial = memorialData.bossMemorials.find(m => m.bossId === bossId);
         
-        // Clear existing classes and content
-        badgeElement.className = 'boss-status-badge';
-        badgeElement.textContent = '';
+        // Default: hide both badges
+        victoryBadge.style.display = 'none';
+        defeatBadge.style.display = 'none';
         
         if (memorial) {
             const hasVictory = memorial.dateFirstWin;
             const hasDefeat = memorial.dateFirstLost;
             
-            if (hasVictory && hasDefeat) {
-                // Both victory and defeat achieved - show both badges
-                badgeElement.classList.add('both');
-                badgeElement.textContent = '🏆☠';
-                badgeElement.title = '勝利済み・敗北済み';
-            } else if (hasVictory) {
-                // Victory only
-                badgeElement.classList.add('victory');
-                badgeElement.textContent = '🏆';
-                badgeElement.title = '勝利済み';
-            } else if (hasDefeat) {
-                // Defeat only
-                badgeElement.classList.add('defeat');
-                badgeElement.textContent = '☠';
-                badgeElement.title = '敗北済み';
+            if (hasVictory) {
+                // Show victory badge
+                victoryBadge.style.display = 'flex';
+                victoryBadge.textContent = '🏆';
+                victoryBadge.title = '勝利済み';
             }
-        }
-        
-        // If no memorial or no battles fought, hide the badge
-        if (!memorial || (!memorial.dateFirstWin && !memorial.dateFirstLost)) {
-            badgeElement.style.display = 'none';
-        } else {
-            badgeElement.style.display = 'flex';
+            
+            if (hasDefeat) {
+                // Show defeat badge
+                defeatBadge.style.display = 'flex';
+                defeatBadge.textContent = '☠';
+                defeatBadge.title = '敗北済み';
+            }
         }
     }
     

--- a/src/game/scenes/BossSelectScene.ts
+++ b/src/game/scenes/BossSelectScene.ts
@@ -165,7 +165,7 @@ export class BossSelectScene {
             if (hasDefeat) {
                 // Show defeat badge
                 defeatBadge.style.display = 'flex';
-                defeatBadge.textContent = '☠';
+                defeatBadge.textContent = '💀';
                 defeatBadge.title = '敗北済み';
             }
         }

--- a/src/game/scenes/BossSelectScene.ts
+++ b/src/game/scenes/BossSelectScene.ts
@@ -150,12 +150,21 @@ export class BossSelectScene {
         badgeElement.textContent = '';
         
         if (memorial) {
-            // If both victory and defeat exist, prioritize victory
-            if (memorial.dateFirstWin) {
+            const hasVictory = memorial.dateFirstWin;
+            const hasDefeat = memorial.dateFirstLost;
+            
+            if (hasVictory && hasDefeat) {
+                // Both victory and defeat achieved - show both badges
+                badgeElement.classList.add('both');
+                badgeElement.textContent = '🏆☠';
+                badgeElement.title = '勝利済み・敗北済み';
+            } else if (hasVictory) {
+                // Victory only
                 badgeElement.classList.add('victory');
                 badgeElement.textContent = '🏆';
                 badgeElement.title = '勝利済み';
-            } else if (memorial.dateFirstLost) {
+            } else if (hasDefeat) {
+                // Defeat only
                 badgeElement.classList.add('defeat');
                 badgeElement.textContent = '☠';
                 badgeElement.title = '敗北済み';

--- a/src/index.html
+++ b/src/index.html
@@ -94,6 +94,7 @@
                         <!-- Boss Cards -->
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="swamp-dragon">
+                                <div class="boss-status-badge" id="boss-status-swamp-dragon"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🐲 沼のドラゴン</h3>
                                     <p class="card-text">高い攻撃力を持つドラゴン。炎のブレスに注意！</p>
@@ -104,6 +105,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="dark-ghost">
+                                <div class="boss-status-badge" id="boss-status-dark-ghost"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">👻 闇のおばけ</h3>
                                     <p class="card-text">状態異常攻撃を多用する。魅了に注意！</p>
@@ -114,6 +116,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="mech-spider">
+                                <div class="boss-status-badge" id="boss-status-mech-spider"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🕷️ 機械のクモ</h3>
                                     <p class="card-text">拘束攻撃を頻発する。捕まらないよう注意！</p>
@@ -124,6 +127,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="dream-demon">
+                                <div class="boss-status-badge" id="boss-status-dream-demon"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">😈 夢魔ちゃん</h3>
                                     <p class="card-text">多種多様なデバフで相手を弱らせる淫魔。デバフ重ね掛けに注意！</p>
@@ -134,6 +138,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="scorpion-carrier">
+                                <div class="boss-status-badge" id="boss-status-scorpion-carrier"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🦂 運び屋のサソリ</h3>
                                     <p class="card-text">砂漠を徘徊する半機械のサソリ。麻酔や毒の注射に注意！</p>
@@ -144,6 +149,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="mikan-dragon">
+                                <div class="boss-status-badge" id="boss-status-mikan-dragon"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🍊 蜜柑ドラゴン</h3>
                                     <p class="card-text">蜜柑の香りを放つ甘いドラゴン。魅了と粘液攻撃に注意！</p>
@@ -154,6 +160,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="sea-kraken">
+                                <div class="boss-status-badge" id="boss-status-sea-kraken"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🦑 海のクラーケン</h3>
                                     <p class="card-text">深海の紫色の巨大イカ。触手の吸引力とイカスミの催眠効果に注意！</p>
@@ -164,6 +171,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="aqua-serpent">
+                                <div class="boss-status-badge" id="boss-status-aqua-serpent"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🐍 アクアサーペント</h3>
                                     <p class="card-text">大海原を泳ぐ神秘的な海蛇型の龍。透明な体内で生命力を吸収する習性を持つ！</p>
@@ -174,6 +182,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="underground-worm">
+                                <div class="boss-status-badge" id="boss-status-underground-worm"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🪨 地底のワーム</h3>
                                     <small class="text-muted">Level 5 - 洞窟・地下世界</small>
@@ -185,6 +194,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="clean-master">
+                                <div class="boss-status-badge" id="boss-status-clean-master"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🧹 クリーンマスター</h3>
                                     <small class="text-muted">Level 6 - 遺跡・廃墟</small>
@@ -196,6 +206,7 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="bat-vampire">
+                                <div class="boss-status-badge" id="boss-status-bat-vampire"></div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🦇 コウモリヴァンパイア</h3>
                                     <p class="card-text">古城に住む紳士的なコウモリの獣人。表向きは優雅だが、内心は獲物を陥れることに喜びを感じている。</p>

--- a/src/index.html
+++ b/src/index.html
@@ -394,7 +394,7 @@
                                     <button id="struggle-btn" class="btn btn-warning" title="拘束から脱出を試みる（成功率は試行回数で上昇）">💪 もがく</button>
                                     <button id="struggle-skill-special-btn" class="btn btn-outline-warning" title="拘束状態専用：脱出確率2倍（30MP）">🔥 あばれる (30MP)</button>
                                     <button id="stay-still-btn" class="btn btn-info" title="体力を回復する（最大HPの5%）">😌 じっとする</button>
-                                    <button id="give-up-btn" class="btn btn-secondary" title="何もしない">☠️ なすがまま</button>
+                                    <button id="give-up-btn" class="btn btn-secondary" title="何もしない">️ 💀なすがまま</button>
                                     <!-- Omamori button will be dynamically inserted here -->
                                     <div id="omamori-special-container" class="d-grid gap-2"></div>
                                 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -94,7 +94,10 @@
                         <!-- Boss Cards -->
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="swamp-dragon">
-                                <div class="boss-status-badge" id="boss-status-swamp-dragon"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-swamp-dragon"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-swamp-dragon"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🐲 沼のドラゴン</h3>
                                     <p class="card-text">高い攻撃力を持つドラゴン。炎のブレスに注意！</p>
@@ -105,7 +108,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="dark-ghost">
-                                <div class="boss-status-badge" id="boss-status-dark-ghost"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-dark-ghost"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-dark-ghost"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">👻 闇のおばけ</h3>
                                     <p class="card-text">状態異常攻撃を多用する。魅了に注意！</p>
@@ -116,7 +122,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="mech-spider">
-                                <div class="boss-status-badge" id="boss-status-mech-spider"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-mech-spider"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-mech-spider"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🕷️ 機械のクモ</h3>
                                     <p class="card-text">拘束攻撃を頻発する。捕まらないよう注意！</p>
@@ -127,7 +136,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="dream-demon">
-                                <div class="boss-status-badge" id="boss-status-dream-demon"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-dream-demon"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-dream-demon"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">😈 夢魔ちゃん</h3>
                                     <p class="card-text">多種多様なデバフで相手を弱らせる淫魔。デバフ重ね掛けに注意！</p>
@@ -138,7 +150,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="scorpion-carrier">
-                                <div class="boss-status-badge" id="boss-status-scorpion-carrier"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-scorpion-carrier"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-scorpion-carrier"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🦂 運び屋のサソリ</h3>
                                     <p class="card-text">砂漠を徘徊する半機械のサソリ。麻酔や毒の注射に注意！</p>
@@ -149,7 +164,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="mikan-dragon">
-                                <div class="boss-status-badge" id="boss-status-mikan-dragon"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-mikan-dragon"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-mikan-dragon"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🍊 蜜柑ドラゴン</h3>
                                     <p class="card-text">蜜柑の香りを放つ甘いドラゴン。魅了と粘液攻撃に注意！</p>
@@ -160,7 +178,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="sea-kraken">
-                                <div class="boss-status-badge" id="boss-status-sea-kraken"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-sea-kraken"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-sea-kraken"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🦑 海のクラーケン</h3>
                                     <p class="card-text">深海の紫色の巨大イカ。触手の吸引力とイカスミの催眠効果に注意！</p>
@@ -171,7 +192,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="aqua-serpent">
-                                <div class="boss-status-badge" id="boss-status-aqua-serpent"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-aqua-serpent"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-aqua-serpent"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🐍 アクアサーペント</h3>
                                     <p class="card-text">大海原を泳ぐ神秘的な海蛇型の龍。透明な体内で生命力を吸収する習性を持つ！</p>
@@ -182,7 +206,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="underground-worm">
-                                <div class="boss-status-badge" id="boss-status-underground-worm"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-underground-worm"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-underground-worm"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🪨 地底のワーム</h3>
                                     <small class="text-muted">Level 5 - 洞窟・地下世界</small>
@@ -194,7 +221,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="clean-master">
-                                <div class="boss-status-badge" id="boss-status-clean-master"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-clean-master"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-clean-master"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🧹 クリーンマスター</h3>
                                     <small class="text-muted">Level 6 - 遺跡・廃墟</small>
@@ -206,7 +236,10 @@
                         
                         <div class="col-md-4 mb-4">
                             <div class="card bg-secondary h-100 boss-card" data-boss="bat-vampire">
-                                <div class="boss-status-badge" id="boss-status-bat-vampire"></div>
+                                <div class="boss-status-container">
+                                    <div class="boss-status-badge victory" id="boss-status-victory-bat-vampire"></div>
+                                    <div class="boss-status-badge defeat" id="boss-status-defeat-bat-vampire"></div>
+                                </div>
                                 <div class="card-body text-center">
                                     <h3 class="card-title">🦇 コウモリヴァンパイア</h3>
                                     <p class="card-text">古城に住む紳士的なコウモリの獣人。表向きは優雅だが、内心は獲物を陥れることに喜びを感じている。</p>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -71,6 +71,7 @@ body {
     cursor: pointer;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     border: 2px solid transparent;
+    position: relative;
 }
 
 .boss-card:hover {
@@ -82,6 +83,56 @@ body {
 .boss-card.selected {
     border-color: #007bff;
     box-shadow: 0 0 15px rgba(0, 123, 255, 0.5);
+}
+
+/* Boss Status Badge */
+.boss-status-badge {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 10;
+    min-width: 32px;
+    min-height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.7);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.boss-status-badge.victory {
+    background: linear-gradient(135deg, #ffd700, #ffed4e);
+    color: #8b4513;
+    border: 2px solid #ffa500;
+}
+
+.boss-status-badge.defeat {
+    background: linear-gradient(135deg, #6c757d, #495057);
+    color: #ffffff;
+    border: 2px solid #343a40;
+}
+
+.boss-status-badge:hover {
+    transform: scale(1.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+/* Victory badge animation */
+.boss-status-badge.victory {
+    animation: trophy-glow 2s ease-in-out infinite alternate;
+}
+
+@keyframes trophy-glow {
+    from {
+        box-shadow: 0 2px 6px rgba(255, 215, 0, 0.4);
+    }
+    to {
+        box-shadow: 0 4px 15px rgba(255, 215, 0, 0.7);
+    }
 }
 
 /* Guest Character Attribution */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -116,6 +116,14 @@ body {
     border: 2px solid #343a40;
 }
 
+.boss-status-badge.both {
+    background: linear-gradient(135deg, #ffd700 0%, #ffed4e 50%, #6c757d 50%, #495057 100%);
+    color: #ffffff;
+    border: 2px solid #ffa500;
+    min-width: 48px;
+    font-size: 14px;
+}
+
 .boss-status-badge:hover {
     transform: scale(1.1);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
@@ -126,11 +134,28 @@ body {
     animation: trophy-glow 2s ease-in-out infinite alternate;
 }
 
+/* Both badges animation */
+.boss-status-badge.both {
+    animation: both-glow 3s ease-in-out infinite alternate;
+}
+
 @keyframes trophy-glow {
     from {
         box-shadow: 0 2px 6px rgba(255, 215, 0, 0.4);
     }
     to {
+        box-shadow: 0 4px 15px rgba(255, 215, 0, 0.7);
+    }
+}
+
+@keyframes both-glow {
+    0% {
+        box-shadow: 0 2px 6px rgba(255, 215, 0, 0.4);
+    }
+    50% {
+        box-shadow: 0 4px 12px rgba(108, 117, 125, 0.6);
+    }
+    100% {
         box-shadow: 0 4px 15px rgba(255, 215, 0, 0.7);
     }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -85,16 +85,22 @@ body {
     box-shadow: 0 0 15px rgba(0, 123, 255, 0.5);
 }
 
-/* Boss Status Badge */
-.boss-status-badge {
+/* Boss Status Container */
+.boss-status-container {
     position: absolute;
     top: 8px;
     left: 8px;
     z-index: 10;
+    display: flex;
+    gap: 4px;
+}
+
+/* Boss Status Badge */
+.boss-status-badge {
     min-width: 32px;
     min-height: 32px;
     border-radius: 50%;
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
     font-size: 16px;
@@ -116,14 +122,6 @@ body {
     border: 2px solid #343a40;
 }
 
-.boss-status-badge.both {
-    background: linear-gradient(135deg, #ffd700 0%, #ffed4e 50%, #6c757d 50%, #495057 100%);
-    color: #ffffff;
-    border: 2px solid #ffa500;
-    min-width: 48px;
-    font-size: 14px;
-}
-
 .boss-status-badge:hover {
     transform: scale(1.1);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
@@ -134,28 +132,11 @@ body {
     animation: trophy-glow 2s ease-in-out infinite alternate;
 }
 
-/* Both badges animation */
-.boss-status-badge.both {
-    animation: both-glow 3s ease-in-out infinite alternate;
-}
-
 @keyframes trophy-glow {
     from {
         box-shadow: 0 2px 6px rgba(255, 215, 0, 0.4);
     }
     to {
-        box-shadow: 0 4px 15px rgba(255, 215, 0, 0.7);
-    }
-}
-
-@keyframes both-glow {
-    0% {
-        box-shadow: 0 2px 6px rgba(255, 215, 0, 0.4);
-    }
-    50% {
-        box-shadow: 0 4px 12px rgba(108, 117, 125, 0.6);
-    }
-    100% {
         box-shadow: 0 4px 15px rgba(255, 215, 0, 0.7);
     }
 }


### PR DESCRIPTION
## Summary
- ボス選択画面の各ボスカード左上に戦闘履歴バッジを表示
- 勝利済み：🏆 ゴールドバッジ（アニメーション付き）
- 敗北済み：💀 グレーバッジ
- 両方達成時は2つのバッジが横並びで表示される収集要素UI

## 主な変更内容
- **HTML**: 各ボスカードにバッジコンテナと個別バッジ要素を追加
- **CSS**: バッジの絶対配置、スタイリング、アニメーション効果を実装
- **TypeScript**: MemorialSystemから戦闘記録を取得してバッジ表示制御

## 実装仕様
- 勝利のみ：🏆 (左側に1つ)
- 敗北のみ：💀 (左側に1つ)
- 両方達成：🏆💀 (左右に並んで2つ表示)
- 未戦闘：バッジなし

## バッジ機能
- ツールチップでステータス表示（勝利済み/敗北済み）
- 勝利バッジには金色グローアニメーション
- ホバー時のスケール変化エフェクト
- レスポンシブ対応

## Test plan
- [x] 各ボスの戦闘記録に応じてバッジが正しく表示される
- [x] 勝利・敗北・両方・未戦闘の全パターンでバッジ表示が適切
- [x] アニメーション・ホバーエフェクトが正常動作
- [x] TypeScript型チェック・ビルドが成功
- [x] レスポンシブデザインで各画面サイズに対応

🤖 Generated with [Claude Code](https://claude.ai/code)