### PR TITLE
✨ アビリティレベル最大時の表示改善

### DIFF
--- a/src/game/scenes/managers/PlayerModalManager.ts
+++ b/src/game/scenes/managers/PlayerModalManager.ts
@@ -6,6 +6,7 @@ import type { BootstrapModal } from '../../types/bootstrap';
 import { TrophyDisplayComponent } from '../components/TrophyDisplayComponent';
 import { EquipmentSelectorComponent } from '../components/EquipmentSelectorComponent';
 import { SkillDisplayComponent } from '../components/SkillDisplayComponent';
+import { Player } from '@/game/entities/Player';
 
 export class PlayerModalManager {
     private game: Game;
@@ -367,7 +368,7 @@ export class PlayerModalManager {
     /**
      * Get max level experience requirement
      */
-    private getMaxLevelRequirement(player: any): number {
+    private getMaxLevelRequirement(player: Player): number {
         return player.abilitySystem.getRequiredExperienceForLevel(AbilitySystem.MAX_LEVEL);
     }
     

--- a/src/game/scenes/managers/PlayerModalManager.ts
+++ b/src/game/scenes/managers/PlayerModalManager.ts
@@ -10,6 +10,10 @@ import { SkillDisplayComponent } from '../components/SkillDisplayComponent';
 export class PlayerModalManager {
     private game: Game;
     private playerModal: BootstrapModal | null = null;
+    
+    // CSS class constants
+    private static readonly PROGRESS_BAR_WARNING = 'progress-bar bg-warning progress-bar-striped progress-bar-animated';
+    private static readonly PROGRESS_BAR_INFO = 'progress-bar bg-info';
 
     constructor(game: Game) {
         this.game = game;
@@ -93,7 +97,7 @@ export class PlayerModalManager {
             // Update next level requirement display
             if (data.level >= AbilitySystem.MAX_LEVEL) {
                 // Max level: show total experience required for max level
-                const maxLevelRequirement = player.abilitySystem.getRequiredExperienceForLevel(AbilitySystem.MAX_LEVEL);
+                const maxLevelRequirement = this.getMaxLevelRequirement(player);
                 this.updateElement(`${prefix}-next`, maxLevelRequirement.toString());
             } else {
                 this.updateElement(`${prefix}-next`, (data.experience + data.experienceToNext).toString());
@@ -119,17 +123,13 @@ export class PlayerModalManager {
         if (data.level >= AbilitySystem.MAX_LEVEL) {
             // Max level: 100% progress with warning style and stripes
             progressElement.style.width = '100%';
-            progressElement.className = 'progress-bar bg-warning progress-bar-striped progress-bar-animated';
+            progressElement.className = PlayerModalManager.PROGRESS_BAR_WARNING;
         } else if (data.experienceToNext > 0) {
             // Normal level progression using AbilitySystem methods
-            const currentLevelRequirement = abilitySystem.getRequiredExperienceForLevel(data.level);
-            const nextLevelRequirement = abilitySystem.getRequiredExperienceForLevel(data.level + 1);
-            const currentLevelExp = data.experience - currentLevelRequirement;
-            const levelRangeExp = nextLevelRequirement - currentLevelRequirement;
-            const percentage = (currentLevelExp / levelRangeExp) * 100;
+            const { percentage } = this.calculateExperienceData(data, abilitySystem);
             
             progressElement.style.width = `${percentage}%`;
-            progressElement.className = 'progress-bar bg-info';
+            progressElement.className = PlayerModalManager.PROGRESS_BAR_INFO;
         }
     }
 
@@ -143,7 +143,7 @@ export class PlayerModalManager {
         // Update next level requirement display for stats section
         if (data.level >= AbilitySystem.MAX_LEVEL) {
             // Max level: show total experience required for max level
-            const maxLevelRequirement = abilitySystem.getRequiredExperienceForLevel(AbilitySystem.MAX_LEVEL);
+            const maxLevelRequirement = this.getMaxLevelRequirement(this.game.getPlayer());
             this.updateElement('explorer-next-stats', maxLevelRequirement.toString());
         } else {
             this.updateElement('explorer-next-stats', (data.experience + data.experienceToNext).toString());
@@ -154,17 +154,13 @@ export class PlayerModalManager {
             if (data.level >= AbilitySystem.MAX_LEVEL) {
                 // Max level: 100% progress with warning style and stripes
                 statsProgressElement.style.width = '100%';
-                statsProgressElement.className = 'progress-bar bg-warning progress-bar-striped progress-bar-animated';
+                statsProgressElement.className = PlayerModalManager.PROGRESS_BAR_WARNING;
             } else if (data.experienceToNext > 0) {
                 // Normal level progression using AbilitySystem methods
-                const currentLevelRequirement = abilitySystem.getRequiredExperienceForLevel(data.level);
-                const nextLevelRequirement = abilitySystem.getRequiredExperienceForLevel(data.level + 1);
-                const currentLevelExp = data.experience - currentLevelRequirement;
-                const levelRangeExp = nextLevelRequirement - currentLevelRequirement;
-                const percentage = (currentLevelExp / levelRangeExp) * 100;
+                const { percentage } = this.calculateExperienceData(data, abilitySystem);
                 
                 statsProgressElement.style.width = `${percentage}%`;
-                statsProgressElement.className = 'progress-bar bg-info';
+                statsProgressElement.className = PlayerModalManager.PROGRESS_BAR_INFO;
             }
         }
     }
@@ -263,7 +259,7 @@ export class PlayerModalManager {
             // Update next level requirement display for explorer tab
             if (explorerData.level >= AbilitySystem.MAX_LEVEL) {
                 // Max level: show total experience required for max level
-                const maxLevelRequirement = player.abilitySystem.getRequiredExperienceForLevel(AbilitySystem.MAX_LEVEL);
+                const maxLevelRequirement = this.getMaxLevelRequirement(player);
                 this.updateElement('explorer-next', maxLevelRequirement.toString());
             } else {
                 this.updateElement('explorer-next', (explorerData.experience + explorerData.experienceToNext).toString());
@@ -368,6 +364,26 @@ export class PlayerModalManager {
         });
     }
 
+    /**
+     * Get max level experience requirement
+     */
+    private getMaxLevelRequirement(player: any): number {
+        return player.abilitySystem.getRequiredExperienceForLevel(AbilitySystem.MAX_LEVEL);
+    }
+    
+    /**
+     * Calculate experience data for progress bar
+     */
+    private calculateExperienceData(data: any, abilitySystem: AbilitySystem): { currentLevelExp: number; levelRangeExp: number; percentage: number } {
+        const currentLevelRequirement = abilitySystem.getRequiredExperienceForLevel(data.level);
+        const nextLevelRequirement = abilitySystem.getRequiredExperienceForLevel(data.level + 1);
+        const currentLevelExp = data.experience - currentLevelRequirement;
+        const levelRangeExp = nextLevelRequirement - currentLevelRequirement;
+        const percentage = (currentLevelExp / levelRangeExp) * 100;
+        
+        return { currentLevelExp, levelRangeExp, percentage };
+    }
+    
     /**
      * Helper method to update element text content
      */

--- a/src/game/systems/AbilitySystem.ts
+++ b/src/game/systems/AbilitySystem.ts
@@ -35,6 +35,7 @@ export interface ExtendedItem {
 }
 
 export class AbilitySystem {
+    public static readonly MAX_LEVEL = 10;
     public abilities: Map<AbilityType, AbilityData> = new Map();
     
     constructor() {
@@ -67,7 +68,7 @@ export class AbilitySystem {
         let level = 0;
         while (this.getRequiredExperienceForLevel(level + 1) <= totalExperience) {
             level++;
-            if (level >= 10) break; // Max level is 10
+            if (level >= AbilitySystem.MAX_LEVEL) break; // Max level is 10
         }
         return level;
     }
@@ -86,7 +87,7 @@ export class AbilitySystem {
         
         // Recalculate level based on total experience
         const newLevel = this.calculateLevelFromExperience(ability.experience);
-        ability.level = Math.min(newLevel, 10); // Cap at level 10
+        ability.level = Math.min(newLevel, AbilitySystem.MAX_LEVEL); // Cap at max level
         
         const leveledUp = ability.level > previousLevel;
         
@@ -109,7 +110,7 @@ export class AbilitySystem {
      */
     getExperienceToNextLevel(abilityType: AbilityType): number {
         const ability = this.abilities.get(abilityType);
-        if (!ability || ability.level >= 10) return 0;
+        if (!ability || ability.level >= AbilitySystem.MAX_LEVEL) return 0;
         
         const nextLevelRequirement = this.getRequiredExperienceForLevel(ability.level + 1);
         return nextLevelRequirement - ability.experience;


### PR DESCRIPTION
## 概要

アビリティレベルが最大（レベル10）に到達したときの表示を改善しました。

## 変更内容

### UI改善
- **プログレスバー**: 100%表示、黄色（`bg-warning`）、ストライプアニメーション表示
- **経験値分母**: レベル10必要経験値（50,000）を表示

### コード品質向上
- `AbilitySystem.MAX_LEVEL`定数を追加してハードコーディングを排除
- 既存の`getRequiredExperienceForLevel()`メソッドを活用したリファクタリング
- コードの重複を排除し、保守性を向上

## 修正ファイル
- `src/game/systems/AbilitySystem.ts`: MAX_LEVEL定数追加
- `src/game/scenes/managers/PlayerModalManager.ts`: プログレスバー表示ロジック改善

## テスト内容
- [ ] アビリティレベル10到達時のプログレスバー表示確認
- [ ] 経験値分母の表示確認（50,000）
- [ ] ストライプアニメーションの動作確認
- [ ] 型チェック・ビルド成功確認

## スクリーンショット

アビリティレベル最大時：
- プログレスバーが100%、黄色、ストライプアニメーション表示
- 分母が50,000（レベル10必要経験値）に変更

🤖 Generated with [Claude Code](https://claude.ai/code)