### PR TITLE
Adjust struggle action success rates

### DIFF
--- a/src/game/entities/PlayerBattleActions.ts
+++ b/src/game/entities/PlayerBattleActions.ts
@@ -33,7 +33,7 @@ export class PlayerBattleActions {
         let baseSuccessRate = PlayerConstants.STRUGGLE_BASE_SUCCESS_RATE
             + (this.player.struggleAttempts - 1) * PlayerConstants.STRUGGLE_SUCCESS_INCREASE_PER_ATTEMPT;
         
-        // Apply agility Bonus
+        // Apply agility bonus
         const agilityBonus = this.player.abilitySystem.getAgilityEscapeBonus();
         baseSuccessRate *= 1 + agilityBonus;
         

--- a/src/game/entities/PlayerBattleActions.ts
+++ b/src/game/entities/PlayerBattleActions.ts
@@ -29,17 +29,20 @@ export class PlayerBattleActions {
         
         this.player.struggleAttempts++;
         
-        // Base success rate starts at 30% and increases by 20% each attempt
-        let baseSuccessRate = PlayerConstants.STRUGGLE_BASE_SUCCESS_RATE + (this.player.struggleAttempts - 1) * PlayerConstants.STRUGGLE_SUCCESS_INCREASE_PER_ATTEMPT;
-        baseSuccessRate = Math.min(baseSuccessRate, PlayerConstants.STRUGGLE_MAX_SUCCESS_RATE);
+        // Base success rate starts at 20% and increases by 20% each attempt
+        let baseSuccessRate = PlayerConstants.STRUGGLE_BASE_SUCCESS_RATE
+            + (this.player.struggleAttempts - 1) * PlayerConstants.STRUGGLE_SUCCESS_INCREASE_PER_ATTEMPT;
         
-        // Apply agility bonus
+        // Apply agility Bonus
         const agilityBonus = this.player.abilitySystem.getAgilityEscapeBonus();
-        baseSuccessRate += agilityBonus;
+        baseSuccessRate *= 1 + agilityBonus;
         
         // Apply charm modifier
         const modifier = this.player.statusEffects.getStruggleModifier();
-        const finalSuccessRate = baseSuccessRate * modifier;
+        baseSuccessRate *= modifier;
+        
+        // Cap success rate at 90%
+        const finalSuccessRate = Math.min(baseSuccessRate, PlayerConstants.STRUGGLE_MAX_SUCCESS_RATE);
         
         const success = Math.random() < finalSuccessRate;
         

--- a/src/game/entities/PlayerConstants.ts
+++ b/src/game/entities/PlayerConstants.ts
@@ -32,8 +32,8 @@ export const CRAFTWORK_HEALING_MULTIPLIER_BASE = 1;
 /** 防御時の100%ダメージカット率 */
 export const DEFEND_DAMAGE_CUT_RATE = 1.0;
 
-/** もがく行動の基本成功率（30%） */
-export const STRUGGLE_BASE_SUCCESS_RATE = 0.3;
+/** もがく行動の基本成功率（20%） */
+export const STRUGGLE_BASE_SUCCESS_RATE = 0.2;
 
 /** もがく試行回数ごとの成功率増加（20%） */
 export const STRUGGLE_SUCCESS_INCREASE_PER_ATTEMPT = 0.2;

--- a/src/game/entities/SkillStrategy.ts
+++ b/src/game/entities/SkillStrategy.ts
@@ -75,15 +75,14 @@ export class StruggleStrategy implements SkillStrategy {
         
         // Calculate enhanced struggle success rate
         let baseSuccessRate = PlayerConstants.STRUGGLE_BASE_SUCCESS_RATE + (player.struggleAttempts) * PlayerConstants.STRUGGLE_SUCCESS_INCREASE_PER_ATTEMPT;
-        baseSuccessRate = Math.min(baseSuccessRate, 1.0);
         
         // Apply agility bonus
         const agilityBonus = player.abilitySystem.getAgilityEscapeBonus();
-        baseSuccessRate += agilityBonus;
+        baseSuccessRate *= 1 + agilityBonus;
         
         const modifier = player.statusEffects.getStruggleModifier();
         let finalSuccessRate = baseSuccessRate * modifier * successMultiplier;
-        finalSuccessRate = Math.min(finalSuccessRate, 1.0);
+        finalSuccessRate = Math.min(finalSuccessRate, PlayerConstants.STRUGGLE_MAX_SUCCESS_RATE);
         
         const success = Math.random() < finalSuccessRate;
         player.struggleAttempts++;

--- a/src/game/systems/AbilitySystem.ts
+++ b/src/game/systems/AbilitySystem.ts
@@ -157,13 +157,13 @@ export class AbilitySystem {
     }
     
     /**
-     * Calculate agility restrain escape bonus (5% per level)
+     * Calculate agility restrain escape bonus (10% per level)
      */
     getAgilityEscapeBonus(): number {
         const agilityAbility = this.abilities.get(AbilityType.Agility);
         if (!agilityAbility) return 0;
         
-        return agilityAbility.level * 0.05; // 5% per level
+        return agilityAbility.level * 0.1; // 10% per level
     }
     
     /**


### PR DESCRIPTION
Modify the base success rate for struggle actions from 30% to 20% and adjust the agility escape bonus calculation. Cap the final success rate at 90% to enhance gameplay balance.