### PR TITLE
Fix unused getAccuracyModifier issue and apply accuracy adjustments

### DIFF
--- a/src/game/entities/Boss.ts
+++ b/src/game/entities/Boss.ts
@@ -468,13 +468,15 @@ export class Boss extends Actor {
     private executeAttackAction(action: BossAction, player: Player): string[] {
         const messages: string[] = [];
         const baseDamage = this.calculateActionDamage(action) || this.attackPower;
+        const accuracyModifier = this.statusEffects.getAccuracyModifier();
         const attackResult = calculateAttackResult(
             baseDamage, 
             player.isKnockedOut(), 
             action.hitRate, 
             action.criticalRate,
             action.damageVarianceMin,
-            action.damageVarianceMax
+            action.damageVarianceMax,
+            accuracyModifier
         );
         
         if (attackResult.message) {
@@ -505,13 +507,15 @@ export class Boss extends Actor {
         
         const baseDamage = this.calculateActionDamage(action);
         if (baseDamage && baseDamage > 0) {
+            const accuracyModifier = this.statusEffects.getAccuracyModifier();
             const attackResult = calculateAttackResult(
                 baseDamage, 
                 player.isKnockedOut(), 
                 action.hitRate, 
                 action.criticalRate,
                 action.damageVarianceMin,
-                action.damageVarianceMax
+                action.damageVarianceMax,
+                accuracyModifier
             );
 
             if (attackResult.isMiss) {
@@ -614,13 +618,15 @@ export class Boss extends Actor {
         
         // Apply variance to absorption amount
         const baseAbsorption = this.calculateActionDamage(action) || Math.floor(player.maxHp * DEFAULT_MAX_HP_ABSORPTION_RATIO);
+        const accuracyModifier = this.statusEffects.getAccuracyModifier();
         const statusAttackResult = calculateAttackResult(
             baseAbsorption, 
             player.isKnockedOut(), 
             action.hitRate, 
             action.criticalRate,
             action.damageVarianceMin,
-            action.damageVarianceMax
+            action.damageVarianceMax,
+            accuracyModifier
         );
         const hpAbsorbed = statusAttackResult.damage;
         
@@ -638,7 +644,8 @@ export class Boss extends Actor {
             1.0, 
             0.0,
             action.damageVarianceMin,
-            action.damageVarianceMax
+            action.damageVarianceMax,
+            accuracyModifier
         );
         const mpDrainAmount = statusMpDrainResult.damage;
         

--- a/src/game/scenes/BattleScene.ts
+++ b/src/game/scenes/BattleScene.ts
@@ -730,11 +730,15 @@ export class BattleScene {
         if (!this.player || !this.boss || !this.playerTurn) return;
         
         const baseDamage = this.player.getAttackPower();
+        const accuracyModifier = this.player.statusEffects.getAccuracyModifier();
         const attackResult = calculateAttackResult(
             baseDamage,
             false,
             1.0,
-            0.05
+            0.05,
+            undefined,
+            undefined,
+            accuracyModifier
         ); // Player attacks are never guaranteed hits
         
         this.addBattleLogMessage(`${this.player.name}の攻撃！`, 'system', 'player');
@@ -827,6 +831,7 @@ export class BattleScene {
                 const skill = skills.find(s => s.id === skillId);
                 
                 let finalDamage = result.damage;
+                const accuracyModifier = this.player.statusEffects.getAccuracyModifier();
                 if (skill && skill.damageVarianceMin !== undefined && skill.damageVarianceMax !== undefined) {
                     // Apply parameters for skills
                     const attackResult = calculateAttackResult(
@@ -835,7 +840,8 @@ export class BattleScene {
                         skill.hitRate, // Use skill's custom hit rate if available
                         skill.criticalRate, // Use skill's custom critical rate if
                         skill.damageVarianceMin,
-                        skill.damageVarianceMax
+                        skill.damageVarianceMax,
+                        accuracyModifier
                     );
                     finalDamage = attackResult.damage;
                     
@@ -844,7 +850,7 @@ export class BattleScene {
                     }
                 } else {
                     // Use default variance for skills without custom settings
-                    const attackResult = calculateAttackResult(result.damage, false);
+                    const attackResult = calculateAttackResult(result.damage, false, undefined, undefined, undefined, undefined, accuracyModifier);
                     finalDamage = attackResult.damage;
                     
                     if (attackResult.isCritical) {

--- a/src/game/utils/CombatUtils.ts
+++ b/src/game/utils/CombatUtils.ts
@@ -42,6 +42,7 @@ export function applyCustomDamageVariance(baseDamage: number, minVariance: numbe
  * @param customCriticalRate カスタムクリティカル率（デフォルトは0.0）
  * @param damageVarianceMin ダメージの最小ゆらぎ（デフォルトは-0.2）
  * @param damageVarianceMax ダメージの最大ゆらぎ（デフォルトは0.2）
+ * @param accuracyModifier 状態異常による命中率修正（デフォルトは1.0）
  * @returns 攻撃結果オブジェクト
  * @property {number} damage - 実際のダメージ
  * @property {boolean} isMiss - ミスしたかどうか
@@ -52,6 +53,7 @@ export function applyCustomDamageVariance(baseDamage: number, minVariance: numbe
  * - `isTargetKnockedOut` がtrueの場合、ヒット率は1.0（必ずヒット）になります。
  * - `customHitRate` と `customCriticalRate` を指定することで、ヒット率とクリティカル率をカスタマイズできます。
  * - `damageVarianceMin` と `damageVarianceMax` を指定することで、ダメージのゆらぎをカスタマイズできます。
+ * - `accuracyModifier` で状態異常による命中率修正を適用できます。
  * - クリティカルヒットの場合、ダメージは通常の3倍になります。
  * - ミスした場合、ダメージは0になります。
  * - ダメージは最終計算時に四捨五入されます。
@@ -62,7 +64,8 @@ export function calculateAttackResult(
     customHitRate?: number,
     customCriticalRate?: number,
     damageVarianceMin?: number,
-    damageVarianceMax?: number
+    damageVarianceMax?: number,
+    accuracyModifier: number = 1.0
 ): AttackResult {
     if (baseDamage <= 0) {
         return {
@@ -75,7 +78,9 @@ export function calculateAttackResult(
     
     // プレイヤーが行動不能の場合、ボスの攻撃はミスしない
     const baseHitRate = customHitRate !== undefined ? customHitRate : 1.0;
-    const hitRate = isTargetKnockedOut ? 1.0 : baseHitRate;
+    // 状態異常による命中率修正を適用
+    const adjustedHitRate = isTargetKnockedOut ? 1.0 : baseHitRate * accuracyModifier;
+    const hitRate = Math.max(0, Math.min(1, adjustedHitRate)); // 0-1の範囲に制限
     
     if (!isTargetKnockedOut && Math.random() >= hitRate) {
         // ミス


### PR DESCRIPTION
Accuracy modifiers now apply to player and boss attacks, ensuring that status effects affecting hit rates function correctly. This change enhances the combat mechanics by integrating accuracy adjustments into damage calculations.