### PR TITLE
✨️ 双面の道化師デュアル実装

### DIFF
--- a/src/game/data/bosses/dual-jester.ts
+++ b/src/game/data/bosses/dual-jester.ts
@@ -149,7 +149,7 @@ const dualJesterDevourActions: BossAction[] = [
             '狂気の人格：「君はとても美味しいよ...もう離さない」',
             '<TARGET>は二重人格の狂気に翻弄され続ける！'
         ],
-        damageFormula: (user: Boss) => user.attackPower * 2.0,
+        damageFormula: (user: Boss) => user.attackPower * 1.8,
         statusEffect: StatusEffectType.Bipolar,
         statusChance: 0.70,
         weight: 35,
@@ -165,7 +165,7 @@ const dualJesterDevourActions: BossAction[] = [
             '<USER>の二つの人格が同時に<TARGET>を消化しようとする！',
             '<TARGET>の最大HPが二重の力で削られていく...'
         ],
-        damageFormula: (user: Boss) => user.attackPower * 2.5,
+        damageFormula: (user: Boss) => user.attackPower * 2.0,
         weight: 30,
         playerStateCondition: 'eaten'
     },
@@ -244,7 +244,22 @@ const dualJesterAIStrategy = (boss: Boss, player: Player, turn: number): BossAct
     const hasTransformed = boss.getCustomVariable<boolean>('hasTransformed', false);
     if (isPhase2 && !hasTransformed) {
         boss.setCustomVariable('hasTransformed', true);
-        // 変身メッセージは戦闘システムで自動表示される
+        // 専用の変身メッセージを追加
+        return {
+            id: 'phase-transform',
+            type: ActionType.Attack,
+            name: '本性覚醒',
+            description: '双面の道化師の真の姿が露わになる',
+            messages: [
+                '「...あれ？まだ遊びたいの？」（声が低く変化）',
+                'デュアルの顔が反転し、その瞳が狂気に染まった！',
+                '可愛らしい道化師の仮面が剥がれ落ち、真の恐怖が姿を現す！',
+                '「なら...本気で遊ぼうか」（完全に別人格）'
+            ],
+            damageFormula: (user: Boss) => user.attackPower * 1.2,
+            weight: 1,
+            playerStateCondition: 'normal'
+        };
     }
     
     boss.setCustomVariable('currentPhase', isPhase2 ? 2 : 1);
@@ -288,7 +303,7 @@ const dualJesterAIStrategy = (boss: Boss, player: Player, turn: number): BossAct
     if (player.isKnockedOut()) {
         if (player.isRestrained() && isPhase2) {
             // 第2フェーズで拘束+戦闘不能時は80%で捕食
-            if (Math.random() < 0.8) {
+            if (Math.random() < 0.65) {
                 return {
                     id: 'final-swallow',
                     type: ActionType.EatAttack,

--- a/src/game/data/bosses/dual-jester.ts
+++ b/src/game/data/bosses/dual-jester.ts
@@ -1,0 +1,501 @@
+import { BossData, ActionType, BossAction, Boss } from '../../entities/Boss';
+import { Player } from '../../entities/Player';
+import { StatusEffectType } from '../../systems/StatusEffectTypes';
+
+// 第1フェーズ: 表の顔（偽装フェーズ）- 可愛い演技と手加減
+const dualJesterPhase1Actions: BossAction[] = [
+    {
+        id: 'playful-pat',
+        type: ActionType.Attack,
+        name: '遊びのぽんぽん',
+        description: '可愛く手をぽんぽんと叩く',
+        messages: [
+            '「一緒に遊ぼうよ〜♪」',
+            '<USER>は<TARGET>を可愛く軽くぽんぽんと叩く！',
+            'とても軽いタッチで、まるで遊んでいるようだ'
+        ],
+        damageFormula: (user: Boss) => Math.max(1, user.attackPower * 0.15), // 非常に軽いダメージ
+        hitRate: 0.98,
+        weight: 35,
+        playerStateCondition: 'normal'
+    },
+    {
+        id: 'playful-bind',
+        type: ActionType.RestraintAttack,
+        name: 'お遊び拘束',
+        description: '遊びのつもりで軽く拘束する',
+        messages: [
+            '「はーい、おいかけっこの時間だよ〜♪」',
+            '<USER>は<TARGET>を遊びのつもりで軽く捕まえる！',
+            '<TARGET>は拘束されたが、なんとなく脱出しやすそうだ...'
+        ],
+        statusEffect: StatusEffectType.FalseSecurity,
+        statusChance: 0.60,
+        weight: 25,
+        canUse: (_boss, player, _turn) => {
+            return !player.isRestrained() && !player.isEaten() && Math.random() < 0.40;
+        }
+    },
+    {
+        id: 'tickle-attack',
+        type: ActionType.StatusAttack,
+        name: 'くすぐり攻撃',
+        description: 'くすぐって笑わせようとする',
+        messages: [
+            '「くすぐっちゃうぞ〜♪」',
+            '<USER>は<TARGET>をくすぐって笑わせようとする！',
+            '<TARGET>は笑いそうになった...'
+        ],
+        damageFormula: (user: Boss) => Math.max(1, user.attackPower * 0.20),
+        statusEffect: StatusEffectType.Charm,
+        statusChance: 0.50,
+        weight: 30,
+        playerStateCondition: 'normal'
+    },
+    {
+        id: 'pretend-swallow',
+        type: ActionType.EatAttack,
+        name: '捕食ごっこ',
+        description: '食べる真似をするが実際は食べない',
+        messages: [
+            '「食べちゃうぞ〜♪ でも冗談だよ〜」',
+            '<USER>は<TARGET>を口に入れるような素振りを見せる！',
+            'でも実際は演技のようで、本気ではないようだ...'
+        ],
+        weight: 20,
+        canUse: (_boss, player, _turn) => {
+            return player.isRestrained() && Math.random() < 0.25;
+        }
+    }
+];
+
+// 第2フェーズ: 裏の顔（本気フェーズ）- HP50%以下で豹変
+const dualJesterPhase2Actions: BossAction[] = [
+    {
+        id: 'true-restraint',
+        type: ActionType.RestraintAttack,
+        name: '真の拘束',
+        description: '本気の拘束技を繰り出す',
+        messages: [
+            '「...さっきは手加減していただけだ」（声が低く変化）',
+            '<USER>の顔が反転し、色調が暗く変化する！',
+            '<TARGET>が強力な拘束に捕らわれた！'
+        ],
+        statusEffect: StatusEffectType.Manic,
+        statusChance: 0.70,
+        weight: 35,
+        canUse: (_boss, player, _turn) => {
+            return !player.isRestrained() && !player.isEaten();
+        }
+    },
+    {
+        id: 'manic-squeeze',
+        type: ActionType.Attack,
+        name: '狂気締め付け',
+        description: '狂気の笑いと共に強く締め付ける',
+        messages: [
+            '「もっと...もっと一緒にいよう...♪」（狂気の笑い）',
+            '<USER>は<TARGET>を狂気的な力で締め付ける！',
+            '<TARGET>は強力な圧迫感に苦しんだ！'
+        ],
+        damageFormula: (user: Boss) => user.attackPower * 1.8,
+        statusEffect: StatusEffectType.Bipolar,
+        statusChance: 0.60,
+        weight: 30,
+        playerStateCondition: 'restrained'
+    },
+    {
+        id: 'dual-personality-lick',
+        type: ActionType.StatusAttack,
+        name: '二重人格なめまわし',
+        description: '表裏の人格が交互に現れる攻撃',
+        messages: [
+            '「大丈夫、痛くないよ〜」→「痛がってる顔、とても美しいね」',
+            '<USER>の人格が急激に変化しながら<TARGET>を舐め回す！',
+            '<TARGET>は混乱と恐怖に包まれた！'
+        ],
+        damageFormula: (user: Boss) => user.attackPower * 1.5,
+        statusEffect: StatusEffectType.Confusion,
+        statusChance: 0.80,
+        weight: 25,
+        playerStateCondition: 'restrained'
+    },
+    {
+        id: 'true-devour',
+        type: ActionType.EatAttack,
+        name: '真の捕食',
+        description: '今度は本当に食べてしまう',
+        messages: [
+            '「今度は本当に食べてあげる...永遠に一緒にいられるよ」',
+            '<USER>の狂気の笑みが<TARGET>を恐怖に陥れる！',
+            '<TARGET>は真の恐怖の中で飲み込まれていく！'
+        ],
+        weight: 25,
+        canUse: (_boss, player, _turn) => {
+            return player.isRestrained() && player.getHpPercentage() < 0.30;
+        }
+    }
+];
+
+// 第3フェーズ: 体内環境（狂気の遊び場）
+const dualJesterDevourActions: BossAction[] = [
+    {
+        id: 'madness-playground',
+        type: ActionType.DevourAttack,
+        name: '狂気の遊び場',
+        description: '体内の歪んだ空間でプレイヤーを翻弄する',
+        messages: [
+            '優しい人格：「ずっと一緒にいようね♪」',
+            '狂気の人格：「君はとても美味しいよ...もう離さない」',
+            '<TARGET>は二重人格の狂気に翻弄され続ける！'
+        ],
+        damageFormula: (user: Boss) => user.attackPower * 2.0,
+        statusEffect: StatusEffectType.Bipolar,
+        statusChance: 0.70,
+        weight: 35,
+        playerStateCondition: 'eaten'
+    },
+    {
+        id: 'dual-digestion',
+        type: ActionType.DevourAttack,
+        name: '二重消化',
+        description: '表裏の人格が同時に消化を進める',
+        messages: [
+            '「一緒に遊ぼうよ〜♪」「永遠に我が物にしてやる...」',
+            '<USER>の二つの人格が同時に<TARGET>を消化しようとする！',
+            '<TARGET>の最大HPが二重の力で削られていく...'
+        ],
+        damageFormula: (user: Boss) => user.attackPower * 2.5,
+        weight: 30,
+        playerStateCondition: 'eaten'
+    },
+    {
+        id: 'nightmare-embrace',
+        type: ActionType.DevourAttack,
+        name: '悪夢の抱擁',
+        description: '甘い夢と恐ろしい悪夢を同時に見せる',
+        messages: [
+            '「楽しい夢を見せてあげる♪」「...それとも悪夢がお好み？」',
+            '<USER>は<TARGET>に甘美な夢と恐ろしい悪夢を同時に体験させる！',
+            '<TARGET>は現実と幻想の境界を見失った！'
+        ],
+        damageFormula: (user: Boss) => user.attackPower * 1.8,
+        statusEffect: StatusEffectType.FalseSecurity,
+        statusChance: 0.60,
+        weight: 25,
+        playerStateCondition: 'eaten'
+    }
+];
+
+// 第4フェーズ: 敗北後の永続支配
+const dualJesterEternalActions: BossAction[] = [
+    {
+        id: 'eternal-playmate',
+        type: ActionType.PostDefeatedAttack,
+        name: '永遠の遊び相手',
+        description: '永遠に遊び続ける相手として保管する',
+        messages: [
+            '「今日から君は僕だけのもの」',
+            '<USER>は<TARGET>を永遠の遊び相手として体内に留める！',
+            '目覚めることはないが、それも愛の形だと囁かれる...'
+        ],
+        weight: 35,
+        playerStateCondition: 'defeated'
+    },
+    {
+        id: 'perfect-toy',
+        type: ActionType.PostDefeatedAttack,
+        name: '完璧な玩具',
+        description: '理想的な玩具として永続的に保管する',
+        messages: [
+            '「君はとても良い玩具だった...永遠に大切にしよう」',
+            '<USER>は<TARGET>を最高の玩具として認定し、大切に保管する！',
+            '心配しないで、とても楽しい夢を見せてあげると約束される...'
+        ],
+        statusEffect: StatusEffectType.Bipolar,
+        statusChance: 0.80,
+        weight: 30,
+        playerStateCondition: 'defeated'
+    },
+    {
+        id: 'endless-game',
+        type: ActionType.PostDefeatedAttack,
+        name: '終わらない遊び',
+        description: '永続的な遊びのサイクルを開始する',
+        messages: [
+            '「遊びは終わらないよ...ずっと、ずっと♪」',
+            '<USER>は<TARGET>を永続的な遊びのサイクルに組み込む！',
+            '<TARGET>は表裏の人格に代わる代わる遊ばれ続ける...'
+        ],
+        weight: 25,
+        playerStateCondition: 'defeated'
+    }
+];
+
+// AI戦略: 二面性とフェーズ管理
+const dualJesterAIStrategy = (boss: Boss, player: Player, turn: number): BossAction => {
+    const playerHpPercentage = player.getHpPercentage();
+    const bossHpPercentage = boss.getHpPercentage();
+    
+    // フェーズ判定: HP50%以下で第2フェーズ（裏の顔）に切り替え
+    const isPhase2 = bossHpPercentage <= 0.50;
+    
+    // カスタム変数でフェーズ切り替えを管理
+    const hasTransformed = boss.getCustomVariable<boolean>('hasTransformed', false);
+    if (isPhase2 && !hasTransformed) {
+        boss.setCustomVariable('hasTransformed', true);
+        // 変身メッセージは戦闘システムで自動表示される
+    }
+    
+    boss.setCustomVariable('currentPhase', isPhase2 ? 2 : 1);
+    boss.setCustomVariable('currentTurn', turn);
+    
+    // プレイヤーが敗北状態の場合
+    if (player.isDefeated()) {
+        let postDefeatedTurn = boss.getCustomVariable<number>('postDefeatedTurn', 0);
+        postDefeatedTurn++;
+        boss.setCustomVariable('postDefeatedTurn', postDefeatedTurn);
+        
+        const eternalActions = dualJesterEternalActions;
+        const totalWeight = eternalActions.reduce((sum, action) => sum + action.weight, 0);
+        let random = Math.random() * totalWeight;
+        
+        for (const action of eternalActions) {
+            random -= action.weight;
+            if (random <= 0) {
+                return action;
+            }
+        }
+        return eternalActions[0];
+    }
+    
+    // プレイヤーが食べられた状態
+    if (player.isEaten()) {
+        const devourActions = dualJesterDevourActions;
+        const totalWeight = devourActions.reduce((sum, action) => sum + action.weight, 0);
+        let random = Math.random() * totalWeight;
+        
+        for (const action of devourActions) {
+            random -= action.weight;
+            if (random <= 0) {
+                return action;
+            }
+        }
+        return devourActions[0];
+    }
+    
+    // プレイヤーが戦闘不能状態
+    if (player.isKnockedOut()) {
+        if (player.isRestrained() && isPhase2) {
+            // 第2フェーズで拘束+戦闘不能時は80%で捕食
+            if (Math.random() < 0.8) {
+                return {
+                    id: 'final-swallow',
+                    type: ActionType.EatAttack,
+                    name: '最終捕食',
+                    description: '完全に支配下に置くために飲み込む',
+                    messages: [
+                        '「これで君は永遠に僕のものだ...」',
+                        '<USER>は<TARGET>を完全に支配するために飲み込む！',
+                        '<TARGET>は狂気の遊び場へと運ばれていく！'
+                    ],
+                    weight: 1
+                };
+            }
+        }
+    }
+    
+    // フェーズに応じた行動選択
+    let availableActions: BossAction[];
+    
+    if (isPhase2) {
+        // 第2フェーズ: 裏の顔（本気モード）
+        if (player.isRestrained()) {
+            availableActions = dualJesterPhase2Actions.filter(action => 
+                action.playerStateCondition === 'restrained' || !action.playerStateCondition
+            );
+        } else {
+            availableActions = dualJesterPhase2Actions.filter(action => 
+                action.playerStateCondition === 'normal' || !action.playerStateCondition
+            );
+        }
+    } else {
+        // 第1フェーズ: 表の顔（演技モード）
+        if (player.isRestrained()) {
+            // 第1フェーズでは拘束状態でも軽い攻撃のみ
+            availableActions = dualJesterPhase1Actions.filter(action => 
+                action.type !== ActionType.RestraintAttack
+            );
+        } else {
+            availableActions = dualJesterPhase1Actions;
+        }
+    }
+    
+    // canUse条件でフィルタリング
+    availableActions = availableActions.filter(action => {
+        if (action.canUse) {
+            return action.canUse(boss, player, turn);
+        }
+        return true;
+    });
+    
+    if (availableActions.length === 0) {
+        return isPhase2 ? dualJesterPhase2Actions[0] : dualJesterPhase1Actions[0];
+    }
+    
+    // 重み付きランダム選択
+    const totalWeight = availableActions.reduce((sum, action) => sum + action.weight, 0);
+    let random = Math.random() * totalWeight;
+    
+    for (const action of availableActions) {
+        random -= action.weight;
+        if (random <= 0) {
+            return action;
+        }
+    }
+    
+    return availableActions[0];
+};
+
+export const dualJesterData: BossData = {
+    id: 'dual-jester',
+    name: 'DualJester',
+    displayName: '🎭 双面の道化師デュアル',
+    description: '二面性を持つ不気味で可愛い道化師',
+    questNote: '廃遊園地の奥から、可愛らしい道化師が現れた。子供のような無邪気な笑顔で「一緒に遊ぼうよ〜♪」と誘いかけてくるが、その瞳の奥に何か別の意図が見え隠れしている。時折見せる表情の変化が、この存在の真の危険性を物語っている...',
+    maxHp: 280,
+    attackPower: 20,
+    actions: dualJesterPhase1Actions
+        .concat(dualJesterPhase2Actions)
+        .concat(dualJesterDevourActions)
+        .concat(dualJesterEternalActions),
+    icon: '🎭',
+    explorerLevelRequired: 9,
+    
+    battleStartMessages: [
+        {
+            speaker: 'player',
+            style: 'default',
+            text: 'あなたは廃遊園地の奥で小さな道化師と遭遇した。'
+        },
+        {
+            speaker: 'boss',
+            style: 'talk',
+            text: 'わーい！新しいお友達だ〜♪ 一緒に遊ぼうよ〜！'
+        },
+        {
+            speaker: 'boss',
+            style: 'default',
+            text: '双面の道化師デュアルがくるくる回りながらあなたに近づいてくる。その無邪気な笑顔の裏に、何か別の感情が見え隠れしている...'
+        },
+        {
+            speaker: 'boss',
+            style: 'talk',
+            text: 'ねぇねぇ、どんな遊びがしたい？ 僕はどんな遊びでも知ってるよ〜♪'
+        }
+    ],
+    
+    victoryMessages: [
+        {
+            speaker: 'boss',
+            style: 'talk',
+            text: 'あ〜あ、疲れちゃった...でも楽しかったよ♪',
+        },
+        {
+            speaker: 'boss',
+            style: 'talk',
+            text: 'また遊ぼうね！今度はもっと、もっと楽しい遊びをしようね〜♪'
+        },
+        {
+            speaker: 'boss',
+            style: 'default',
+            text: '双面の道化師デュアルは満足そうに微笑んで、くるくる回りながら廃遊園地の奥へと消えていった...'
+        }
+    ],
+    
+    // 記念品設定
+    victoryTrophy: {
+        name: '二面鏡',
+        description: '双面の道化師が持っていた特殊な鏡。時々敵の次の行動が見える不思議な力を秘めている。表と裏、どちらが真実なのかは見る者次第。'
+    },
+    defeatTrophy: {
+        name: '道化師の鈴',
+        description: '双面の道化師の帽子についていた金色の鈴。可愛い音色に隠された狂気により、聞いた者は現実と幻想の境界を見失う。時に相手を混乱させる力を持つ。'
+    },
+    
+    personality: [
+        '一緒に遊ぼうよ〜♪',
+        'どっちが本当の僕かな〜？',
+        'もっと楽しい遊びをしようね♪',
+        '君はとても良い玩具だね...',
+        '永遠に一緒にいようね',
+        'フフフ...面白い'
+    ],
+    
+    aiStrategy: dualJesterAIStrategy,
+    
+    // カスタム変数の初期値
+    customVariables: {
+        hasTransformed: false,       // 第2フェーズへの変身フラグ
+        currentPhase: 1,             // 現在のフェーズ (1: 表の顔, 2: 裏の顔)
+        currentTurn: 0,              // 現在ターン数
+        postDefeatedTurn: 0,         // 敗北後ターン数
+        dualPersonalityMode: false   // 二重人格モード
+    }
+};
+
+// フィニッシュムーブの実装
+dualJesterData.finishingMove = function(): string[] {
+    return [
+        '双面の道化師デュアルは<TARGET>を完全に支配した！',
+        '表の人格：「だいすき〜♪ ずっと一緒にいようね〜♪」',
+        '裏の人格：「...ついに完璧な玩具を手に入れた」',
+        '<TARGET>は道化師の精神世界に取り込まれ、表裏の人格が延々と入れ替わる空間で永遠に遊ばれ続けることになった！',
+        '可愛い笑い声と不気味な笑い声が交互に響く中、<TARGET>は現実と幻想の境界を完全に見失ってしまった...'
+    ];
+};
+
+// 状況別台詞システム
+dualJesterData.getDialogue = function(situation: 'battle-start' | 'player-restrained' | 'player-eaten' | 'player-escapes' | 'low-hp' | 'victory') {
+    const dialogues: Record<string, string[]> = {
+        'battle-start': [
+            'わーい！新しいお友達だ〜♪',
+            '一緒に遊ぼうよ〜♪',
+            'どんな遊びがしたい？',
+            'ねぇねぇ、遊ぼうよ〜♪'
+        ],
+        'player-restrained': [
+            'やったぁ〜！捕まえた♪',
+            'もう逃げちゃダメだよ〜♪',
+            'これでゆっくり遊べるね〜',
+            '...フフフ、動けないね（声が低く）'
+        ],
+        'player-eaten': [
+            '表：「お腹の中であったか〜い♪」',
+            '裏：「もう二度と外には出さない...」',
+            '表：「ずっと一緒だね〜♪」',
+            '裏：「完璧な玩具の完成だ...」'
+        ],
+        'player-escapes': [
+            'あ〜、逃げちゃった...',
+            '今度はもっと上手に捕まえなきゃ♪',
+            'でも逃げられっこないよ〜♪',
+            '...覚えておくぞ（声が低く）'
+        ],
+        'low-hp': [
+            'あれ？なんか痛い...（表の顔）',
+            '...面白くなってきたな（裏の顔）',
+            'でもまだまだ遊べるもん♪',
+            '本気を出す時が来たようだな...'
+        ],
+        'victory': [
+            '表：「やったぁ〜！勝った勝った♪」',
+            '裏：「当然の結果だ...」',
+            '表：「また遊ぼうね〜♪」',
+            '裏：「次は逃がさないぞ...」'
+        ]
+    };
+    
+    const options = dialogues[situation] || dialogues['battle-start'];
+    return options[Math.floor(Math.random() * options.length)];
+};

--- a/src/game/data/index.ts
+++ b/src/game/data/index.ts
@@ -16,7 +16,8 @@ export const registeredBossIds: string[] = [
     'underground-worm',
     'bat-vampire',
     'fluffy-dragon',
-    'seraph-mascot'
+    'seraph-mascot',
+    'dual-jester'
 ];
 
 /**
@@ -86,6 +87,9 @@ async function loadBossData(id: string): Promise<BossData> {
             break;
         case 'seraph-mascot':
             bossData = (await import('./bosses/seraph-mascot')).seraphMascotData;
+            break;
+        case 'dual-jester':
+            bossData = (await import('./bosses/dual-jester')).dualJesterData;
             break;
         default:
             throw new Error(`Unknown boss ID: ${id}`);

--- a/src/game/systems/StatusEffectTypes.ts
+++ b/src/game/systems/StatusEffectTypes.ts
@@ -101,7 +101,12 @@ export enum StatusEffectType {
     // Seraph Mascot effects
     Blessed = 'blessed',
     Overwhelmed = 'overwhelmed',
-    SalvationState = 'salvation-state'
+    SalvationState = 'salvation-state',
+    
+    // Dual Jester effects
+    FalseSecurity = 'false-security',
+    Manic = 'manic',
+    Bipolar = 'bipolar'
 }
 
 export interface StatusEffect {

--- a/src/game/systems/status-effects/dual-jester-effects.ts
+++ b/src/game/systems/status-effects/dual-jester-effects.ts
@@ -5,8 +5,8 @@ export const dualJesterEffectsConfigs = new Map<StatusEffectType, StatusEffectCo
     [StatusEffectType.FalseSecurity, {
         type: StatusEffectType.FalseSecurity,
         name: '偽りの安心',
-        description: '危険察知能力が大幅に低下し、敵の攻撃予告が見えなくなる',
-        duration: 3,
+        description: '道化師の演技に騙され、危険察知能力が大幅に低下。命中率-30%、被ダメージ+25%',
+        duration: 2,
         category: 'debuff',
         isDebuff: true,
         modifiers: {
@@ -23,7 +23,7 @@ export const dualJesterEffectsConfigs = new Map<StatusEffectType, StatusEffectCo
     [StatusEffectType.Manic, {
         type: StatusEffectType.Manic,
         name: '躁状態',
-        description: '攻撃力が上昇するが防御力と命中率が低下し、行動が予測不能になる',
+        description: '躁状態により攻撃力+50%だが、防御力-30%・命中率-20%。時々自傷や状態変化が発生',
         duration: 4,
         category: 'debuff',
         isDebuff: true,
@@ -33,19 +33,15 @@ export const dualJesterEffectsConfigs = new Map<StatusEffectType, StatusEffectCo
             accuracy: 0.8 // 命中率低下
         },
         onTick: (target: Actor) => {
-            // 20%の確率でBipolarに変化
-            if (Math.random() < 0.20) {
+            // 15%の確率でBipolarに変化（確率調整）
+            if (Math.random() < 0.15) {
                 target.statusEffects.removeEffect(StatusEffectType.Manic);
-                target.statusEffects.addEffect({
-                    type: StatusEffectType.Bipolar,
-                    duration: 3,
-                    name: '双極効果',
-                    description: '全ての状態異常の効果がランダムで正反対になる'
-                });
+                // 正しい呼び出し方法を使用
+                target.statusEffects.addEffect(StatusEffectType.Bipolar, 3);
             }
-            // 10%の確率で自分を攻撃
-            if (Math.random() < 0.10) {
-                const selfDamage = Math.floor(target.maxHp * 0.05);
+            // 8%の確率で自分を攻撃（確率調整）
+            if (Math.random() < 0.08) {
+                const selfDamage = Math.floor(target.maxHp * 0.03); // ダメージ軽減
                 target.takeDamage(selfDamage, null);
             }
         },
@@ -59,8 +55,8 @@ export const dualJesterEffectsConfigs = new Map<StatusEffectType, StatusEffectCo
     [StatusEffectType.Bipolar, {
         type: StatusEffectType.Bipolar,
         name: '双極効果',
-        description: '全ての状態異常の効果がランダムで正反対に変化する混乱状態',
-        duration: 5,
+        description: '双面の狂気により感覚が混乱。毒や火だるまが回復効果に変化することがある（命中率-25%）',
+        duration: 3,
         category: 'debuff',
         isDebuff: true,
         onTick: (target: Actor) => {

--- a/src/game/systems/status-effects/dual-jester-effects.ts
+++ b/src/game/systems/status-effects/dual-jester-effects.ts
@@ -1,0 +1,96 @@
+import { StatusEffectType, StatusEffectConfig } from '../StatusEffectTypes';
+import { Actor } from '../../entities/Actor';
+
+export const dualJesterEffectsConfigs = new Map<StatusEffectType, StatusEffectConfig>([
+    [StatusEffectType.FalseSecurity, {
+        type: StatusEffectType.FalseSecurity,
+        name: '偽りの安心',
+        description: '危険察知能力が大幅に低下し、敵の攻撃予告が見えなくなる',
+        duration: 3,
+        category: 'debuff',
+        isDebuff: true,
+        modifiers: {
+            accuracy: 0.7, // 命中率低下
+            damageReceived: 1.25 // 被ダメージ増加
+        },
+        messages: {
+            onApplyPlayer: '{target}は偽りの安心感に包まれ、油断してしまった...',
+            onTickPlayer: '危険が近づいているのに気づかない...',
+            onRemovePlayer: '{target}は現実の危険に気づいた！'
+        }
+    }],
+    
+    [StatusEffectType.Manic, {
+        type: StatusEffectType.Manic,
+        name: '躁状態',
+        description: '攻撃力が上昇するが防御力と命中率が低下し、行動が予測不能になる',
+        duration: 4,
+        category: 'debuff',
+        isDebuff: true,
+        modifiers: {
+            attackPower: 1.5, // 攻撃力上昇
+            damageReceived: 1.3, // 防御力低下
+            accuracy: 0.8 // 命中率低下
+        },
+        onTick: (target: Actor) => {
+            // 20%の確率でBipolarに変化
+            if (Math.random() < 0.20) {
+                target.statusEffects.removeEffect(StatusEffectType.Manic);
+                target.statusEffects.addEffect({
+                    type: StatusEffectType.Bipolar,
+                    duration: 3,
+                    name: '双極効果',
+                    description: '全ての状態異常の効果がランダムで正反対になる'
+                });
+            }
+            // 10%の確率で自分を攻撃
+            if (Math.random() < 0.10) {
+                const selfDamage = Math.floor(target.maxHp * 0.05);
+                target.takeDamage(selfDamage, null);
+            }
+        },
+        messages: {
+            onApplyPlayer: '{target}は躁状態に陥り、行動が不安定になった！',
+            onTickPlayer: '躁状態で感情が激しく揺れ動いている...',
+            onRemovePlayer: '{target}の感情が落ち着いた'
+        }
+    }],
+    
+    [StatusEffectType.Bipolar, {
+        type: StatusEffectType.Bipolar,
+        name: '双極効果',
+        description: '全ての状態異常の効果がランダムで正反対に変化する混乱状態',
+        duration: 5,
+        category: 'debuff',
+        isDebuff: true,
+        onTick: (target: Actor) => {
+            // 状態異常の効果を反転させる（実装は複雑なので基本的なダメージのみ）
+            const allEffects = target.statusEffects.getAllEffects();
+            const otherEffects = allEffects.filter(effect => effect.type !== StatusEffectType.Bipolar);
+            
+            if (otherEffects.length > 0 && Math.random() < 0.30) {
+                // 30%の確率で他の状態異常の効果を反転
+                const randomEffect = otherEffects[Math.floor(Math.random() * otherEffects.length)];
+                
+                // 毒→回復、麻痺→素早さ上昇の効果をシミュレート
+                if (randomEffect.type === StatusEffectType.Poison) {
+                    // 毒ダメージの代わりに回復
+                    const healAmount = Math.floor(target.maxHp * 0.03);
+                    target.heal(healAmount);
+                } else if (randomEffect.type === StatusEffectType.Fire) {
+                    // 火だるまダメージの代わりに回復
+                    const healAmount = Math.floor(target.maxHp * 0.05);
+                    target.heal(healAmount);
+                }
+            }
+        },
+        modifiers: {
+            accuracy: 0.75, // 混乱による命中率低下
+        },
+        messages: {
+            onApplyPlayer: '{target}は双極効果に陥り、全ての感覚が混乱した！',
+            onTickPlayer: '状態異常の効果が予測不能に変化している...',
+            onRemovePlayer: '{target}の感覚が正常に戻った'
+        }
+    }]
+]);

--- a/src/game/systems/status-effects/index.ts
+++ b/src/game/systems/status-effects/index.ts
@@ -5,6 +5,7 @@ import { dreamDemonEffectsConfigs } from './dream-demon-effects';
 import { batVampireEffectsConfigs } from './bat-vampire-effects';
 import { fluffyDragonEffectsConfigs } from './fluffy-dragon-effects';
 import { seraphMascotEffectsConfigs } from './seraph-mascot-effects';
+import { dualJesterEffectsConfigs } from './dual-jester-effects';
 
 // Aggregate all status effect configurations
 export const createStatusEffectConfigs = (): Map<StatusEffectType, StatusEffectConfig> => {
@@ -40,8 +41,13 @@ export const createStatusEffectConfigs = (): Map<StatusEffectType, StatusEffectC
         allConfigs.set(key, config);
     }
 
+    // Add dual jester effects
+    for (const [key, config] of dualJesterEffectsConfigs) {
+        allConfigs.set(key, config);
+    }
+
     return allConfigs;
 };
 
 // Export the individual config groups for potential future use
-export { coreStatesConfigs, battleEffectsConfigs, dreamDemonEffectsConfigs, batVampireEffectsConfigs, fluffyDragonEffectsConfigs, seraphMascotEffectsConfigs };
+export { coreStatesConfigs, battleEffectsConfigs, dreamDemonEffectsConfigs, batVampireEffectsConfigs, fluffyDragonEffectsConfigs, seraphMascotEffectsConfigs, dualJesterEffectsConfigs };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1737,3 +1737,50 @@ footer svg {
         opacity: 1;
     }
 }
+
+/* Dual Jester status effects */
+.status-false-security {
+    background: linear-gradient(45deg, #a7f3d0, #6ee7b7);
+    color: #047857;
+    border: 1px solid #10b981;
+    animation: falseGlow 2s ease-in-out infinite alternate;
+}
+
+.status-manic {
+    background: linear-gradient(45deg, #fca5a5, #f87171);
+    color: #7f1d1d;
+    border: 1px solid #dc2626;
+    animation: maniacPulse 0.8s ease-in-out infinite alternate;
+}
+
+.status-bipolar {
+    background: linear-gradient(45deg, #a7f3d0, #fca5a5, #ddd6fe, #fbbf24);
+    background-size: 400% 400%;
+    color: #374151;
+    border: 1px solid #6b7280;
+    animation: bipolarShift 3s ease-in-out infinite;
+}
+
+@keyframes falseGlow {
+    from { box-shadow: 0 0 5px rgba(16, 185, 129, 0.3); }
+    to { box-shadow: 0 0 15px rgba(16, 185, 129, 0.7); }
+}
+
+@keyframes maniacPulse {
+    from { 
+        transform: scale(1); 
+        box-shadow: 0 0 5px rgba(220, 38, 38, 0.4); 
+    }
+    to { 
+        transform: scale(1.05); 
+        box-shadow: 0 0 12px rgba(220, 38, 38, 0.8); 
+    }
+}
+
+@keyframes bipolarShift {
+    0% { background-position: 0% 50%; }
+    25% { background-position: 100% 50%; }
+    50% { background-position: 50% 100%; }
+    75% { background-position: 50% 0%; }
+    100% { background-position: 0% 50%; }
+}


### PR DESCRIPTION
## 概要
「双面の道化師デュアル」ボスを新規実装しました。二面性を持つユニークなボスで、HP50%を境に表の顔（演技モード）から裏の顔（本気モード）へと豹変する特殊なメカニクスを持ちます。

## 実装内容

### 新ボス「双面の道化師デュアル」🎭
- **HP**: 280
- **攻撃力**: 20  
- **エクスプローラーレベル**: 9
- **特徴**: 二面性とフェーズ切り替えシステム

### 実装ファイル
- `src/game/data/bosses/dual-jester.ts` - ボスデータとAI戦略
- `src/game/systems/status-effects/dual-jester-effects.ts` - 専用状態異常設定
- `src/game/systems/StatusEffectTypes.ts` - 新状態異常定義
- `src/styles/main.css` - 専用CSS（アニメーション付き）

### 新状態異常
1. **偽りの安心** (FalseSecurity) - 命中率-30%、被ダメージ+25%
2. **躁状態** (Manic) - 攻撃力+50%、防御力-30%、命中率-20%
3. **双極効果** (Bipolar) - 状態異常の効果がランダムで反転

### 戦闘フェーズ
1. **第1フェーズ**: 表の顔（可愛い演技、軽いダメージ）
2. **変身演出**: HP50%で専用の本性覚醒アクション
3. **第2フェーズ**: 裏の顔（本気モード、高威力攻撃）
4. **体内フェーズ**: 狂気の遊び場での二重人格攻撃
5. **敗北後**: 永遠の遊び相手として支配

## 技術的特徴
- **フェーズ管理**: カスタム変数による状態追跡
- **AI戦略**: プレイヤー状態とフェーズに応じた動的行動選択
- **状態異常システム**: 循環参照を避けた安全な実装
- **視覚効果**: 専用CSSアニメーション（偽りの光、躁状態パルス、双極シフト）

## コードレビュー対応
エージェントによる詳細なコードレビューに基づき以下を修正：
- 状態異常の循環参照バグ修正
- ダメージバランス調整（過剰だった倍率を適正化）
- 確率調整（AI行動の確率を調整）
- フェーズ切り替え演出強化
- 状態異常説明の詳細化

## テスト内容
- [ ] ボス選択画面での表示確認
- [ ] 戦闘開始〜フェーズ1の動作確認  
- [ ] HP50%での変身演出確認
- [ ] フェーズ2の高威力攻撃確認
- [ ] 新状態異常の効果確認
- [ ] 体内フェーズの動作確認
- [ ] 勝利・敗北時のメッセージ確認

🎭 Generated with [Claude Code](https://claude.ai/code)