### PR TITLE
✨ getDebuffChanceModifier()をデバフ確率計算に反映

### DIFF
--- a/src/game/entities/Boss.ts
+++ b/src/game/entities/Boss.ts
@@ -712,7 +712,16 @@ export class Boss extends Actor {
             return messages;
         }
         
-        const statusChance = action.statusChance !== undefined ? action.statusChance : DEFAULT_STATUS_CHANCE;
+        let statusChance = action.statusChance !== undefined ? action.statusChance : DEFAULT_STATUS_CHANCE;
+        
+        // Apply debuff chance modifier only if the status chance is not guaranteed (1.0)
+        if (statusChance < 1.0) {
+            const debuffModifier = player.statusEffects.getDebuffChanceModifier();
+            statusChance = statusChance * debuffModifier;
+            // Clamp the final chance to valid range [0.0, 1.0]
+            statusChance = Math.max(0.0, Math.min(1.0, statusChance));
+        }
+        
         if (Math.random() < statusChance) {
             player.statusEffects.addEffect(action.statusEffect, action.statusDuration);
             messages.push(`${player.name}が${StatusEffectManager.getEffectName(action.statusEffect)}状態になった！`);


### PR DESCRIPTION
## Summary

プレイヤーの状態異常によるデバフ確率修正機能を実際のゲームに反映させました。

- `Boss.ts`の`processStatusEffect`メソッドを修正
- プレイヤーの`getDebuffChanceModifier()`を使用してデバフ確率を動的に変更
- 確実なデバフ（`statusChance = 1.0`）は影響を受けない仕様を維持

## 変更内容

### 修正箇所
- `src/game/entities/Boss.ts:715-723` - デバフ確率計算ロジックの追加

### 実装仕様
1. **条件付き適用**: `statusChance < 1.0`の場合のみ修正値を適用
2. **確率制限**: 最終確率は`0.0-1.0`の範囲に制限
3. **安全性**: 確実なデバフ（確率1.0）は従来通り確実に発動

## テスト結果

- TypeScriptビルド: ✅ 通過
- 開発サーバー起動: ✅ 正常
- 既存機能への影響: ✅ なし

## Test plan

- [ ] 各種ボス戦でデバフ攻撃を受ける
- [ ] プレイヤーの状態異常による確率変化を確認
- [ ] 確率1.0のデバフが影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)