### PR TITLE
🐛 GitHub Pages デプロイ時のアセット404エラー修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,8 @@ export default defineConfig(({ mode }) => {
   const analyze = mode === 'analyze';
 
   return {
+    // Base URL for GitHub Pages deployment
+    base: isProduction ? '/eel-rpg-game/' : '/',
     // Test configuration
     test: {
       globals: true,


### PR DESCRIPTION
## 概要
GitHub Pages デプロイ時にアセットファイル（CSS/JS）が404エラーになる問題を修正

## 問題
- GitHub Pages: `https://leftonbo.github.io/eel-rpg-game/` でアセットが読み込めない
- ローカル開発環境では正常に動作
- 原因: ViteのbaseパスがGitHub Pagesのサブパスに対応していない

## 修正内容
- vite.config.ts に `base: '/eel-rpg-game/'` を追加
- プロダクション環境でのみ適用される条件分岐を実装
- ローカル開発環境への影響なし

## テスト確認
- [x] `npm run typecheck` - 一部の型エラーあり（本修正とは無関係）
- [x] `npm run test` - すべてのテスト通過
- [x] `npm run build` - ビルド成功

🤖 Generated with [Claude Code](https://claude.ai/code)