### PR TITLE
🐛 バトル結果画面のスクロール範囲外はみ出し問題を修正

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1221,6 +1221,58 @@ body {
     .boss-card {
         margin-bottom: 1rem;
     }
+
+    /* Battle Result Mobile Styles */
+    #battle-result-screen .card {
+        max-height: 95vh;
+        margin: 0.5rem;
+    }
+
+    #battle-result-screen .card-body {
+        max-height: calc(95vh - 2rem);
+        padding: 1.5rem;
+    }
+
+    .battle-result-section {
+        max-height: 150px;
+    }
+
+    #battle-result-title {
+        font-size: 1.5rem !important;
+        margin-bottom: 1.5rem !important;
+    }
+
+    #battle-result-continue-btn {
+        font-size: 1rem !important;
+        padding: 0.75rem 1.5rem !important;
+    }
+}
+
+@media (max-width: 576px) {
+    /* Extra small devices */
+    #battle-result-screen .card {
+        max-height: 98vh;
+        margin: 0.25rem;
+    }
+
+    #battle-result-screen .card-body {
+        max-height: calc(98vh - 1.5rem);
+        padding: 1rem;
+    }
+
+    .battle-result-section {
+        max-height: 120px;
+    }
+
+    #battle-result-title {
+        font-size: 1.25rem !important;
+        margin-bottom: 1rem !important;
+    }
+
+    #battle-result-continue-btn {
+        font-size: 0.9rem !important;
+        padding: 0.6rem 1.2rem !important;
+    }
 }
 
 /* Status Card Styles */
@@ -1721,6 +1773,50 @@ footer svg {
 
 .d-none-important {
     display: none !important;
+}
+
+/* Battle Result Screen Styles */
+#battle-result-screen {
+    overflow-y: auto;
+}
+
+#battle-result-screen .card {
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+#battle-result-screen .card-body {
+    max-height: calc(90vh - 2rem);
+    overflow-y: auto;
+    padding: 2rem;
+}
+
+.battle-result-section {
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+/* Battle result scrollbar styling */
+#battle-result-screen .card-body::-webkit-scrollbar,
+.battle-result-section::-webkit-scrollbar {
+    width: 6px;
+}
+
+#battle-result-screen .card-body::-webkit-scrollbar-track,
+.battle-result-section::-webkit-scrollbar-track {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+}
+
+#battle-result-screen .card-body::-webkit-scrollbar-thumb,
+.battle-result-section::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.3);
+    border-radius: 3px;
+}
+
+#battle-result-screen .card-body::-webkit-scrollbar-thumb:hover,
+.battle-result-section::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.5);
 }
 
 /* Bat Vampire Animations */

--- a/src/templates/partials/battle-result-scene.ejs
+++ b/src/templates/partials/battle-result-scene.ejs
@@ -1,6 +1,6 @@
 <!-- Battle Result Screen -->
-<div id="battle-result-screen" class="scene d-none vh-100">
-    <div class="container-fluid h-100 d-flex align-items-center justify-content-center">
+<div id="battle-result-screen" class="scene d-none min-vh-100">
+    <div class="container-fluid py-4 d-flex align-items-center justify-content-center">
         <div class="col-md-8 col-lg-6">
             <div class="card bg-dark border-info">
                 <div class="card-body text-center">
@@ -12,22 +12,22 @@
                     </div>
                     
                     <!-- Level Ups -->
-                    <div id="level-ups" class="mb-4">
+                    <div id="level-ups" class="mb-4 battle-result-section">
                         <!-- Level up details will be populated here -->
                     </div>
                     
                     <!-- New Unlocks -->
-                    <div id="new-unlocks" class="mb-4 max-height-300">
+                    <div id="new-unlocks" class="mb-4 battle-result-section">
                         <!-- New unlock details will be populated here -->
                     </div>
                     
                     <!-- Trophies Earned -->
-                    <div id="trophies-earned" class="mb-4">
+                    <div id="trophies-earned" class="mb-4 battle-result-section">
                         <!-- Trophy details will be populated here -->
                     </div>
                     
                     <!-- New Boss Unlocks -->
-                    <div id="new-boss-unlocks" class="mb-4">
+                    <div id="new-boss-unlocks" class="mb-4 battle-result-section">
                         <!-- New boss unlock details will be populated here -->
                     </div>
                     


### PR DESCRIPTION
## Summary
バトル結果画面でコンテンツが多い場合にカードが画面外にはみ出してしまう問題を修正しました。

- vh-100をmin-vh-100に変更してスクロール可能に設定
- 各セクション（レベルアップ、アンロック、記念品、新ボス解禁）に個別のスクロール制御を追加
- モバイル端末対応のレスポンシブデザインを実装
- カスタムスクロールバーのスタイリングを追加

## 修正前の問題
- 複数のレベルアップや大量のアンロックが発生した際、バトル結果カードが画面の上部にはみ出し、内容が見えなくなる
- 特に小画面やモバイル端末で顕著に発生

## 修正後の改善点
- コンテンツ量に関係なく、すべての結果が適切にスクロール表示される
- 各セクションが独立してスクロール可能になり、操作性が向上
- デスクトップ・モバイル両方で最適な表示を実現

## Test plan
- [x] 大量のレベルアップが発生する状況でのテスト
- [x] 複数のアンロックと記念品が同時に発生する状況でのテスト
- [x] モバイル端末での表示確認
- [x] 型チェックとビルドの成功確認

🤖 Generated with [Claude Code](https://claude.ai/code)