### PR TITLE
🐛 資料庫ページの資料ボタンクリック時の表示不具合を修正

### DIFF
--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -90,7 +90,7 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
 
 **- エルナル**`,
                 requiredExplorerLevel: 1,
-                requiredBossDefeats: ['swamp-dragon'],
+                requiredBossDefeats: [],
                 unlocked: false
             }
         ];
@@ -162,6 +162,7 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
             button.dataset.documentId = doc.id;
             
             if (doc.unlocked) {
+                button.classList.remove('btn-outline-secondary');
                 button.classList.add('btn-outline-info');
                 button.innerHTML = `
                     <div class="d-flex justify-content-between align-items-center">
@@ -191,11 +192,18 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
      * 文書内容の表示
      */
     private showDocument(documentId: string): void {
+        console.log('showDocument called with ID:', documentId);
         const doc = this.documents.find(d => d.id === documentId);
-        if (!doc || !doc.unlocked) return;
+        if (!doc || !doc.unlocked) {
+            console.log('Document not found or not unlocked:', doc);
+            return;
+        }
         
         const contentContainer = document.getElementById('library-document-content');
-        if (!contentContainer) return;
+        if (!contentContainer) {
+            console.log('Content container not found');
+            return;
+        }
         
         // Markdownの簡易変換（実際のMarkdownパーサーは今後実装）
         const htmlContent = this.convertMarkdownToHtml(doc.content);

--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -103,8 +103,10 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
         // 文書選択イベント（動的に追加される要素用）
         document.addEventListener('click', (event) => {
             const target = event.target as HTMLElement;
-            if (target.classList.contains('library-document-btn')) {
-                const documentId = target.dataset.documentId;
+            // クリックされた要素から最も近い .library-document-btn を探す
+            const button = target.closest('.library-document-btn') as HTMLElement;
+            if (button) {
+                const documentId = button.dataset.documentId;
                 if (documentId) {
                     this.showDocument(documentId);
                 }

--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -194,16 +194,13 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
      * 文書内容の表示
      */
     private showDocument(documentId: string): void {
-        console.log('showDocument called with ID:', documentId);
         const doc = this.documents.find(d => d.id === documentId);
         if (!doc || !doc.unlocked) {
-            console.log('Document not found or not unlocked:', doc);
             return;
         }
         
         const contentContainer = document.getElementById('library-document-content');
         if (!contentContainer) {
-            console.log('Content container not found');
             return;
         }
         


### PR DESCRIPTION
## Summary
- 資料庫ページで資料ボタンをクリックしても内容が表示されない問題を修正
- 解禁条件を緩和し、ボス撃破なしでも基本資料を閲覧可能に変更
- ボタンスタイルの重複クラス問題を修正

## Test plan
- [ ] 資料庫ページにアクセス
- [ ] 「エルナルの冒険日記 - 第1章」ボタンをクリック
- [ ] 右側に資料内容が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)