### PR TITLE
✨ ModalUtilsの改良とCLAUDE.md使用方針追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,35 @@ interface PlayerSaveData {
 
 ## 開発方針（最重要）
 
+### ModalUtils の使用方針
+
+ブラウザ標準のダイアログ（`alert()`, `confirm()`, `prompt()`）は使用せず、必ずModalUtilsクラスのメソッドを使用すること。
+
+- **`alert()` の代替**: `ModalUtils.showAlert(message, title?)` を使用
+- **`confirm()` の代替**: `ModalUtils.showConfirm(message, title?)` を使用  
+- **`prompt()` の代替**: `ModalUtils.showPrompt(message, defaultValue?, title?, inputType?)` を使用
+- **通知表示**: `ModalUtils.showToast(message, title?, type?)` を使用
+
+**理由**:
+- Bootstrap 5のモーダルシステムとの統一感
+- ユーザー体験の向上（アニメーション、スタイリング）
+- モバイル環境での一貫した表示
+- カスタマイズ可能性とアクセシビリティの向上
+
+**例**:
+```typescript
+// ❌ 使用しない
+alert('保存しました');
+const result = confirm('削除しますか？');
+const name = prompt('名前を入力してください');
+
+// ✅ 推奨
+await ModalUtils.showAlert('保存しました');
+const result = await ModalUtils.showConfirm('削除しますか？');
+const name = await ModalUtils.showPrompt('名前を入力してください');
+ModalUtils.showToast('データを更新しました', 'データベース', 'success');
+```
+
 ### git コミット方針
 
 Claude Codeは以下の方針に従ってgitコミットを行うこと

--- a/src/game/utils/ModalUtils.ts
+++ b/src/game/utils/ModalUtils.ts
@@ -50,6 +50,7 @@ export class ModalUtils {
      * 
      * @static
      * @param {string} message - 表示するメッセージ
+     * @param {string} [title] - トーストのカスタムタイトル（未指定時はtypeに応じたデフォルトタイトル）
      * @param {'success' | 'error' | 'info' | 'warning'} [type='info'] - トーストのタイプ
      * @returns {void}
      * 
@@ -57,23 +58,41 @@ export class ModalUtils {
      * 
      * @example
      * ```typescript
-     * // 成功メッセージ
-     * ModalUtils.showToast('保存しました！', 'success');
+     * // 成功メッセージ（デフォルトタイトル）
+     * ModalUtils.showToast('保存しました！', undefined, 'success');
      * 
-     * // エラーメッセージ
-     * ModalUtils.showToast('エラーが発生しました', 'error');
+     * // カスタムタイトル付きメッセージ
+     * ModalUtils.showToast('データを更新しました', 'データベース', 'success');
      * 
      * // 情報メッセージ（デフォルト）
      * ModalUtils.showToast('処理を開始しました');
+     * 
+     * // 従来の使用方法（後方互換性維持）
+     * ModalUtils.showToast('エラーが発生しました', 'error');  // messageとtypeの順序
      * ```
      */
-    static showToast(message: string, type: 'success' | 'error' | 'info' | 'warning' = 'info'): void {
+    static showToast(message: string, titleOrType?: string | 'success' | 'error' | 'info' | 'warning', type?: 'success' | 'error' | 'info' | 'warning'): void {
+        // 引数の解析：後方互換性を保つため
+        let actualTitle: string | undefined;
+        let actualType: 'success' | 'error' | 'info' | 'warning' = 'info';
+
+        if (typeof titleOrType === 'string' && (titleOrType === 'success' || titleOrType === 'error' || titleOrType === 'info' || titleOrType === 'warning')) {
+            // 従来の使用方法: showToast(message, type)
+            actualType = titleOrType;
+            actualTitle = undefined;
+        } else {
+            // 新しい使用方法: showToast(message, title?, type?)
+            actualTitle = titleOrType as string | undefined;
+            actualType = type || 'info';
+        }
+
         const toastContainer = document.getElementById('toast-container');
         if (!toastContainer) return;
 
         const toastId = `toast-${Date.now()}`;
-        const bgClass = this.getToastBgClass(type);
-        const iconClass = this.getToastIcon(type);
+        const bgClass = this.getToastBgClass(actualType);
+        const iconClass = this.getToastIcon(actualType);
+        const displayTitle = actualTitle || this.getToastTitle(actualType);
 
         // Bootstrap 5公式のToast構造（右下からのスライドイン用）
         const toastHtml = `
@@ -87,7 +106,7 @@ export class ModalUtils {
                  data-bs-autohide="true">
                 <div class="toast-header ${bgClass} text-white">
                     <span class="me-2">${iconClass}</span>
-                    <strong class="me-auto">${this.getToastTitle(type)}</strong>
+                    <strong class="me-auto">${displayTitle}</strong>
                     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="閉じる"></button>
                 </div>
                 <div class="toast-body">


### PR DESCRIPTION
## 概要

ModalUtilsクラスの`showToast`メソッドにタイトル指定機能を追加し、CLAUDE.mdにModalUtilsの使用方針を追加しました。

## 変更内容

### 1. showToastメソッドの改良
- **新しいシグネチャ**: `showToast(message: string, title?: string, type?: 'success' | 'error' | 'info' | 'warning')`
- **後方互換性**: 従来の`showToast(message, type)`も引き続き動作
- **カスタムタイトル**: 任意のタイトルを指定可能、未指定時はデフォルトタイトルを使用

### 2. CLAUDE.mdの更新
- **ModalUtils使用方針セクション**を開発方針に追加
- `alert()`, `confirm()`, `prompt()`の代替としてModalUtilsメソッドを推奨
- Bootstrap 5との統一感とUX向上の理由を明記
- 具体的な使用例とNG例を記載

## 使用例

```typescript
// 新機能：カスタムタイトル付きトースト
ModalUtils.showToast('データを更新しました', 'データベース', 'success');

// 従来通りの使用方法（後方互換性）
ModalUtils.showToast('エラーが発生しました', 'error');

// デフォルトタイトルでの情報表示
ModalUtils.showToast('処理を開始しました');
```

## テスト計画

- [x] 型チェック実行 (`npm run typecheck`)
- [x] 単体テスト実行 (`npm run test`)
- [x] 既存のトースト表示機能の動作確認
- [x] 新しいタイトル指定機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)