### PR TITLE
文書解禁条件に敗北条件を追加

### DIFF
--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -10,6 +10,7 @@ interface LibraryDocument {
     content: string;
     requiredExplorerLevel: number;
     requiredBossDefeats?: string[];
+    requiredBossLosses?: string[];
     unlocked: boolean;
 }
 

--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -202,7 +202,8 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
             try {
                 const bossData = getBossData(bossId);
                 return `${bossData.name}${type === 'defeat' ? '敗北' : '撃破'}`;
-            } catch {
+            } catch (error) {
+                console.error(`Error fetching boss data for ID "${bossId}":`, error);
                 return `${bossId}${type === 'defeat' ? '敗北' : '撃破'}(データ不明)`;
             }
         }).join(', ');

--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -194,6 +194,7 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
                     <small class="text-muted d-block mt-1">
                         必要条件: エクスプローラーLv.${doc.requiredExplorerLevel}
                         ${doc.requiredBossDefeats ? `, ${doc.requiredBossDefeats.join(', ')}撃破` : ''}
+                        ${doc.requiredBossLosses ? `, ${doc.requiredBossLosses.join(', ')}敗北` : ''}
                     </small>
                 `;
             }

--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -40,7 +40,7 @@ export class OutGameLibraryScene extends BaseOutGameScene {
      * 文書データの初期化（簡易実装）
      */
     private initializeDocuments(): void {
-        // 今回は1つのサンプル資料のみ実装
+        // 基本文書とテスト用文書を実装
         this.documents = [
             {
                 id: 'welcome-document',
@@ -92,6 +92,39 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
 **- エルナル**`,
                 requiredExplorerLevel: 1,
                 requiredBossDefeats: [],
+                unlocked: false
+            },
+            {
+                id: 'defeat-reflection',
+                title: '💭 敗北から学ぶこと',
+                content: `# 敗北から学ぶこと
+
+## 最初の挫折
+
+沼のドラゴンに最初に挑戦した時、あっけなく負けちゃった...
+でも、その敗北があったからこそ今の私があるのよね。
+
+## 敗北の意味
+
+負けるって悲しいけれど、それは新しい発見の始まり。
+相手の攻撃パターンを身をもって知ることができるし、
+自分の弱点も見えてくる。
+
+## 成長への第一歩
+
+この敗北の経験が、私をより強い冒険者に変えてくれた。
+準備の大切さ、装備の重要性、戦略の必要性...
+全てを学ぶことができたの。
+
+次に同じボスと戦う時は、きっと違う結果になるはず！
+
+---
+
+*敗北は終わりじゃない。新しい始まりなのよ。*
+
+**- エルナル**`,
+                requiredExplorerLevel: 1,
+                requiredBossLosses: ['swamp-dragon'],
                 unlocked: false
             }
         ];

--- a/src/game/scenes/OutGameLibraryScene.ts
+++ b/src/game/scenes/OutGameLibraryScene.ts
@@ -133,6 +133,9 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
         const defeatedBosses = player.memorialSystem.getAllTrophies()
             .filter(trophy => trophy.type === 'victory')
             .map(trophy => trophy.id.replace('victory-', ''));
+        const lostToBosses = player.memorialSystem.getAllTrophies()
+            .filter(trophy => trophy.type === 'defeat')
+            .map(trophy => trophy.id.replace('defeat-', ''));
         
         this.documents.forEach(doc => {
             // エクスプローラーレベル要求チェック
@@ -146,7 +149,15 @@ HPは低めだけど、状態異常でじわじわと削ってくる戦術。
                 );
             }
             
-            doc.unlocked = levelOk && bossDefeatsOk;
+            // 必要ボス敗北チェック
+            let bossLossesOk = true;
+            if (doc.requiredBossLosses && doc.requiredBossLosses.length > 0) {
+                bossLossesOk = doc.requiredBossLosses.every(bossId => 
+                    lostToBosses.includes(bossId)
+                );
+            }
+            
+            doc.unlocked = levelOk && bossDefeatsOk && bossLossesOk;
         });
     }
     

--- a/src/game/systems/MemorialSystem.ts
+++ b/src/game/systems/MemorialSystem.ts
@@ -231,6 +231,26 @@ export class MemorialSystem {
     }
     
     /**
+     * 敗北したボスのIDリストを取得
+     * @return 敗北したボスのIDの配列
+     */
+    public getDefeatedBossIds(): string[] {
+        return this.getAllTrophies()
+            .filter(trophy => trophy.type === TrophyType.Defeat)
+            .map(trophy => trophy.id.replace(`${TrophyType.Defeat}-`, ''));
+    }
+    
+    /**
+     * 勝利したボスのIDリストを取得
+     * @return 勝利したボスのIDの配列
+     */
+    public getVictoriousBossIds(): string[] {
+        return this.getAllTrophies()
+            .filter(trophy => trophy.type === TrophyType.Victory)
+            .map(trophy => trophy.id.replace(`${TrophyType.Victory}-`, ''));
+    }
+    
+    /**
      * 全てのバトル記録を取得
      * @return バトル記録の配列
      */


### PR DESCRIPTION
## Summary
- LibraryDocumentインターフェースにrequiredBossLossesフィールドを追加
- 文書の解禁条件として「特定のボスに負けた」条件を実装
- UI表示でボス名を表示するよう改善
- MemorialSystemにユーティリティメソッドを追加（getDefeatedBossIds/getVictoriousBossIds）

## Test plan
- [ ] 沼のドラゴンに負けた後、「敗北から学ぶこと」文書が解禁されることを確認
- [ ] 敗北条件が設定されていない既存文書の動作に影響がないことを確認
- [ ] UI表示で「沼のドラゴン敗北」のようにボス名が正しく表示されることを確認
- [ ] エラーハンドリング（存在しないボスID）が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)