### PR TITLE
@types/nodeをv24.1.0に更新（Node.js 20対応）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^24.1.0",
         "@typescript-eslint/eslint-plugin": "^8.36.0",
         "@typescript-eslint/parser": "^8.36.0",
         "ejs": "^3.1.10",
@@ -1028,12 +1028,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3375,10 +3376,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.36.0",
     "@typescript-eslint/parser": "^8.36.0",
     "ejs": "^3.1.10",


### PR DESCRIPTION
## 概要

Node.js 20への移行に伴い、`@types/node`をv20.0.0からv24.1.0に更新しました。

## 変更内容

- `@types/node`: `^20.0.0` → `^24.1.0`
- `undici-types`: 依存関係として`~6.21.0` → `~7.8.0`に更新

## 検証結果

### ✅ 全ての検証項目をクリア

1. **TypeScript型チェック**: `npm run typecheck` - エラーなし
2. **テスト実行**: `npm run test` - 全27テスト通過
3. **ビルド確認**: `npm run build` - 正常完了（992ms）
4. **開発サーバー**: `npm run dev` - 正常起動（localhost:3000）

### セキュリティ

- `npm audit`: 脆弱性なし

## 他のパッケージ状況

以下のパッケージも更新可能ですが、破壊的変更を含むため今回は対象外：

- `rimraf`: 5.0.10 → 6.0.1（APIの大幅変更）
- `rollup-plugin-visualizer`: 5.14.0 → 6.0.3（import構文変更）
- `vite`: 6.3.5 → 7.0.6（メジャーバージョンアップ）

## テスト計画

- [x] TypeScript型チェック
- [x] 単体テスト実行  
- [x] ビルド確認
- [x] 開発サーバー起動確認

🤖 Generated with [Claude Code](https://claude.ai/code)