### PR TITLE
✨未読資料バッジ機能実装

### DIFF
--- a/src/game/data/DocumentLoader.ts
+++ b/src/game/data/DocumentLoader.ts
@@ -18,6 +18,7 @@ interface MarkdownModule {
 export interface LibraryDocument extends LibraryDocumentMetadata {
     content: string;
     unlocked: boolean;
+    isRead: boolean;
 }
 
 /**
@@ -42,7 +43,8 @@ export async function loadAllDocuments(): Promise<void> {
             const docData: LibraryDocument = {
                 ...(module.attributes as LibraryDocumentMetadata),
                 content: module.markdown,
-                unlocked: false
+                unlocked: false,
+                isRead: false
             };
             return docData;
         })
@@ -77,4 +79,24 @@ export function getDocument(id: string): LibraryDocument {
         return documentCache.get(id)!;
     }
     throw new Error(`Document ${id} not loaded. Call loadAllDocuments() first.`);
+}
+
+/**
+ * 解禁済みで未読の文書数を取得
+ * @returns 未読文書数
+ */
+export function getUnreadDocumentCount(): number {
+    const allDocuments = getAllDocuments();
+    return allDocuments.filter(doc => doc.unlocked && !doc.isRead).length;
+}
+
+/**
+ * 解禁済みで未読の文書IDリストを取得
+ * @returns 未読文書IDの配列
+ */
+export function getUnreadDocumentIds(): string[] {
+    const allDocuments = getAllDocuments();
+    return allDocuments
+        .filter(doc => doc.unlocked && !doc.isRead)
+        .map(doc => doc.id);
 }


### PR DESCRIPTION
## 概要
解禁された資料集テキストが未読状態だったら、未読バッジを上部メニューと資料リストに付けて目立たせる機能を実装しました。既読済みの資料のIDはPlayerSaveDataに保存され、永続化されます。

## 実装内容

### セーブデータ管理
- PlayerSaveDataに `readDocuments: string[]` フィールドを追加
- セーブデータバージョンを4から5に更新、自動マイグレーション対応
- 既読マーク、既読チェック、未読ID取得のメソッドを追加

### 資料システム
- DocumentLoaderに未読判定機能を追加（isReadプロパティ、未読カウント機能）
- プレイヤー状態に基づく未読数計算を共通化（getUnreadCountForPlayer関数）
- DocumentLoaderで常に最新の既読状態を反映するよう改善

### UI実装
- 資料リストに未読バッジ表示（Bootstrap 5のbadge bg-warning使用）
- 上部メニューの資料庫ボタンに未読数バッジ表示（全シーン共通）
- 資料閲覧時に自動的に既読状態へ更新、リアルタイムでバッジ消去

### コード品質
- BaseOutGameSceneで全シーン共通の未読バッジ更新機能を実装
- 重複した未読数計算ロジックを共通化し、DRY原則に準拠
- エラーハンドリングを統一し、try-catch で安全性を向上

## テスト項目
- [x] 新規プレイヤーでセーブデータが正常に作成される
- [x] 既存プレイヤーのセーブデータが v4→v5 に正常マイグレーションされる
- [x] 資料解禁時に未読バッジが表示される
- [x] 資料閲覧時に既読状態になりバッジが消去される
- [x] 全シーンで上部メニューの未読数バッジが正常に表示される

## UI/UX向上効果
- プレイヤーが新しく解禁された資料を見つけやすくなる
- 既読・未読の状態が視覚的に分かりやすい
- ゲーム全体のコンテンツ発見性が向上

🤖 Generated with [Claude Code](https://claude.ai/code)