### PR TITLE
メッセージフォーマットの統一

### DIFF
--- a/docs/boss-creation-guide.md
+++ b/docs/boss-creation-guide.md
@@ -76,7 +76,7 @@ interface BossAction {
     type: ActionType;               // 行動タイプ
     name: string;                   // 行動名
     description: string;            // 行動説明
-    messages?: string[];            // メッセージ（<USER>, <TARGET>, <ACTION>を使用）
+    messages?: string[];            // メッセージ（{boss}, {player}を使用）
     damage?: number;                // [非推奨] 固定ダメージ量（damageFormulaを使用推奨）
     damageFormula?: (user: Boss) => number; // ダメージ計算式（ボスのステータスに基づく）
     statusEffect?: StatusEffectType; // 状態異常タイプ
@@ -182,8 +182,8 @@ const newBossActions: BossAction[] = [
         description: '体内で獲物の生命力を吸収する',
         messages: [
             '「グルルル...」',
-            '<USER>が<TARGET>の生命力を吸収している...',
-            '<TARGET>の最大HPが減少していく...'
+            '{boss}が{player}の生命力を吸収している...',
+            '{player}の最大HPが減少していく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 2.0,
         weight: 30,
@@ -200,7 +200,7 @@ const newBossActions: BossAction[] = [
             // カスタム効果の実装例
             if (Math.random() < 0.3) {
                 player.statusEffects.removeEffect(StatusEffectType.Eaten);
-                return ['<TARGET>は攻撃の衝撃で<USER>の体外に吹き飛ばされた！'];
+                return ['{player}は攻撃の衝撃で{boss}の体外に吹き飛ばされた！'];
             }
             return [];
         }
@@ -245,8 +245,8 @@ export const newBossData: BossData = {
 newBossData.finishingMove = function() {
     return [
         '「グルルル...」',
-        '<USER>は<TARGET>を完全に制圧した...',
-        '<TARGET>は<USER>の支配下に置かれることになった...'
+        '{boss}は{player}を完全に制圧した...',
+        '{player}は{boss}の支配下に置かれることになった...'
     ];
 };
 

--- a/docs/drafts/explorer-lv10-boss-proposal.md
+++ b/docs/drafts/explorer-lv10-boss-proposal.md
@@ -91,8 +91,8 @@ explorerLevelRequired: 10
     description: '魂を直接拘束する冥界の鎖でプレイヤーを束縛する',
     messages: [
         '「逃げることは許さない...魂ごと縛り上げてやろう」',
-        '<USER>が冥界の黒い鎖を召喚し、<TARGET>の魂を直接拘束した！',
-        '<TARGET>は魂レベルで拘束され、身動きが取れなくなった！'
+        '{boss}が冥界の黒い鎖を召喚し、{player}の魂を直接拘束した！',
+        '{player}は魂レベルで拘束され、身動きが取れなくなった！'
     ],
     statusEffect: StatusEffectType.SoulChain,
     statusChance: 0.90,
@@ -112,8 +112,8 @@ explorerLevelRequired: 10
     description: '支配下に置いた魂を冥界の体内に収納する',
     messages: [
         '「お前の魂は我が冥界の一部となる...」',
-        '<USER>は<TARGET>の魂を冥界の深淵へと引きずり込む！',
-        '<TARGET>は冥界の支配者の体内に収納され、永遠の隷属が始まった！'
+        '{boss}は{player}の魂を冥界の深淵へと引きずり込む！',
+        '{player}は冥界の支配者の体内に収納され、永遠の隷属が始まった！'
     ],
     weight: 30,
     canUse: (_boss, player, _turn) => {
@@ -131,8 +131,8 @@ explorerLevelRequired: 10
     description: '体内で魂のエネルギーを直接抽出する',
     messages: [
         '「お前の魂の力...すべて我がものに」',
-        '<USER>は体内の<TARGET>から魂のエネルギーを抽出している！',
-        '<TARGET>の生命力と意志力が冥界の支配者に吸収されていく...'
+        '{boss}は体内の{player}から魂のエネルギーを抽出している！',
+        '{player}の生命力と意志力が冥界の支配者に吸収されていく...'
     ],
     damageFormula: (user: Boss) => user.attackPower * 2.2,
     statusEffect: StatusEffectType.SoulDrain,
@@ -151,8 +151,8 @@ explorerLevelRequired: 10
     description: '魂に永続的な支配の刻印を刻み込む',
     messages: [
         '「この刻印により、お前は永遠に我の僕となる...」',
-        '<USER>は<TARGET>の魂に冥界の支配者の刻印を刻み込む！',
-        '<TARGET>の魂に永続的な服従の印が刻まれていく...'
+        '{boss}は{player}の魂に冥界の支配者の刻印を刻み込む！',
+        '{player}の魂に永続的な服従の印が刻まれていく...'
     ],
     damageFormula: (user: Boss) => user.attackPower * 2.5,
     statusEffect: StatusEffectType.WillDomination,
@@ -167,11 +167,11 @@ explorerLevelRequired: 10
 // finishingMove の実装
 abyssLordData.finishingMove = function(): string[] {
     return [
-        '冥界の支配者アビスは<TARGET>の魂を完全に手中に収めた！',
+        '冥界の支配者アビスは{player}の魂を完全に手中に収めた！',
         '「ようやく完璧な僕を手に入れた...」',
-        '<TARGET>の魂が冥界の深淵に引きずり込まれ、アビスの絶対支配下に置かれる！',
-        '冥界の王座の前に跪く<TARGET>...もう二度と自由になることはない',
-        '冥界の支配者の威厳ある笑い声が永遠に響く中、<TARGET>は永遠の隷属が始まったことを悟った...'
+        '{player}の魂が冥界の深淵に引きずり込まれ、アビスの絶対支配下に置かれる！',
+        '冥界の王座の前に跪く{player}...もう二度と自由になることはない',
+        '冥界の支配者の威厳ある笑い声が永遠に響く中、{player}は永遠の隷属が始まったことを悟った...'
     ];
 };
 ```
@@ -185,8 +185,8 @@ abyssLordData.finishingMove = function(): string[] {
     description: '支配下の魂を定期的に査察し、忠誠心を確認する',
     messages: [
         '「忠誠に変わりはないか...確認してやろう」',
-        '<USER>は体内の<TARGET>の魂を定期的に査察している...',
-        '<TARGET>は冥界の支配者による厳格な査察を受け続けている'
+        '{boss}は体内の{player}の魂を定期的に査察している...',
+        '{player}は冥界の支配者による厳格な査察を受け続けている'
     ],
     statusEffect: StatusEffectType.EternalServitude,
     statusChance: 1.0,
@@ -204,8 +204,8 @@ abyssLordData.finishingMove = function(): string[] {
     description: '不完全な忠誠心を持つ魂に再教育を施す',
     messages: [
         '「まだ不完全だ...もっと教育が必要のようだな」',
-        '<USER>は<TARGET>の魂に冥界の掟を再教育している！',
-        '<TARGET>は冥界の支配者による厳しい再教育を受けて、より完璧な僕へと矯正されていく...'
+        '{boss}は{player}の魂に冥界の掟を再教育している！',
+        '{player}は冥界の支配者による厳しい再教育を受けて、より完璧な僕へと矯正されていく...'
     ],
     statusEffect: StatusEffectType.WillDomination,
     statusChance: 0.90,
@@ -253,8 +253,8 @@ explorerLevelRequired: 10
     description: '鎖で繋がった死神の鎌でプレイヤーを拘束する',
     messages: [
         '「死から逃れることはできない...」',
-        '<USER>が鎖鎌を振り回し、<TARGET>を死の鎖で拘束した！',
-        '<TARGET>は死神の鎖に絡め取られ、死の冷気に包まれた！'
+        '{boss}が鎖鎌を振り回し、{player}を死の鎖で拘束した！',
+        '{player}は死神の鎖に絡め取られ、死の冷気に包まれた！'
     ],
     statusEffect: StatusEffectType.DeathMark,
     statusChance: 0.85,
@@ -274,8 +274,8 @@ explorerLevelRequired: 10
     description: '死にかけのプレイヤーを死後の世界へと連れ去る',
     messages: [
         '「もう苦しまなくて良い...永遠の安息を与えてやろう」',
-        '<USER>は<TARGET>を死神のローブで包み込む！',
-        '<TARGET>は死後の世界へと引きずり込まれていく！'
+        '{boss}は{player}を死神のローブで包み込む！',
+        '{player}は死後の世界へと引きずり込まれていく！'
     ],
     weight: 35,
     canUse: (_boss, player, _turn) => {
@@ -293,8 +293,8 @@ explorerLevelRequired: 10
     description: '死後の世界でプレイヤーの魂を審判する',
     messages: [
         '「汝の罪を数え上げよう...」',
-        '<USER>は死後の世界で<TARGET>の魂を厳しく審判している！',
-        '<TARGET>の魂が死神の裁きを受け、罪の重さに苦しんでいる...'
+        '{boss}は死後の世界で{player}の魂を厳しく審判している！',
+        '{player}の魂が死神の裁きを受け、罪の重さに苦しんでいる...'
     ],
     damageFormula: (user: Boss) => user.attackPower * 2.3,
     statusEffect: StatusEffectType.ReaperGaze,
@@ -313,8 +313,8 @@ explorerLevelRequired: 10
     description: '審判の結果、死刑を執行する',
     messages: [
         '「判決：死刑。即刻執行する」',
-        '<USER>は死神の鎌で<TARGET>の魂に死刑を執行する！',
-        '<TARGET>の魂が死神の裁きにより段階的に削られていく...'
+        '{boss}は死神の鎌で{player}の魂に死刑を執行する！',
+        '{player}の魂が死神の裁きにより段階的に削られていく...'
     ],
     damageFormula: (user: Boss) => user.attackPower * 2.8,
     statusEffect: StatusEffectType.DeathSentence,
@@ -329,11 +329,11 @@ explorerLevelRequired: 10
 // finishingMove の実装
 deathReaperData.finishingMove = function(): string[] {
     return [
-        '死神の化身リーパーは<TARGET>に最終審判を下した！',
+        '死神の化身リーパーは{player}に最終審判を下した！',
         '「汝の生涯...すべてを見届けた。判決は既に決まっている」',
-        '<TARGET>の魂が死神の大鎌により刈り取られ、死後の世界への移送が開始される！',
-        '死の法廷で永遠の判決を言い渡される<TARGET>...生者の世界に戻る道は完全に断たれた',
-        '死神の厳粛な宣告が響く中、<TARGET>は永遠に死後の世界の住人となったことを悟った...'
+        '{player}の魂が死神の大鎌により刈り取られ、死後の世界への移送が開始される！',
+        '死の法廷で永遠の判決を言い渡される{player}...生者の世界に戻る道は完全に断たれた',
+        '死神の厳粛な宣告が響く中、{player}は永遠に死後の世界の住人となったことを悟った...'
     ];
 };
 ```
@@ -347,8 +347,8 @@ deathReaperData.finishingMove = function(): string[] {
     description: '死者として永続的に台帳に記録し続ける',
     messages: [
         '「死者台帳に永久記録...これで完了だ」',
-        '<USER>は<TARGET>を死者台帳に永続記録として刻み込んでいる...',
-        '<TARGET>は死神の台帳に記録され、永遠に死者として管理され続ける'
+        '{boss}は{player}を死者台帳に永続記録として刻み込んでいる...',
+        '{player}は死神の台帳に記録され、永遠に死者として管理され続ける'
     ],
     statusEffect: StatusEffectType.AfterlifeBinding,
     statusChance: 1.0,
@@ -366,8 +366,8 @@ deathReaperData.finishingMove = function(): string[] {
     description: '管理下の魂の品質を定期的に査定する',
     messages: [
         '「定期査定の時間だ...魂の劣化具合を確認しよう」',
-        '<USER>は<TARGET>の魂の品質を厳格に査定している！',
-        '<TARGET>は死神による定期的な魂の査定を受け、品質管理の対象として扱われ続けている...'
+        '{boss}は{player}の魂の品質を厳格に査定している！',
+        '{player}は死神による定期的な魂の査定を受け、品質管理の対象として扱われ続けている...'
     ],
     statusEffect: StatusEffectType.ReaperGaze,
     statusChance: 0.85,
@@ -415,8 +415,8 @@ explorerLevelRequired: 10
     description: '虚無から生み出した触手でプレイヤーの存在を拘束する',
     messages: [
         '「存在するということが、そもそも間違いなのだ...」',
-        '<USER>が虚無の触手を伸ばし、<TARGET>の存在そのものを拘束した！',
-        '<TARGET>は虚無の力に捕らわれ、存在が曖昧になっていく！'
+        '{boss}が虚無の触手を伸ばし、{player}の存在そのものを拘束した！',
+        '{player}は虚無の力に捕らわれ、存在が曖昧になっていく！'
     ],
     statusEffect: StatusEffectType.VoidErosion,
     statusChance: 0.80,
@@ -436,8 +436,8 @@ explorerLevelRequired: 10
     description: '存在が薄くなったプレイヤーを虚無へと帰還させる',
     messages: [
         '「すべては虚無に帰る...それが真理だ」',
-        '<USER>は<TARGET>の存在を虚無の世界へと引きずり込む！',
-        '<TARGET>は虚無の王の体内で、非存在の状態へと導かれていく！'
+        '{boss}は{player}の存在を虚無の世界へと引きずり込む！',
+        '{player}は虚無の王の体内で、非存在の状態へと導かれていく！'
     ],
     weight: 30,
     canUse: (_boss, player, _turn) => {
@@ -455,8 +455,8 @@ explorerLevelRequired: 10
     description: 'プレイヤーの概念を段階的に消去する',
     messages: [
         '「『プレイヤー』という概念から消去してやろう...」',
-        '<USER>は虚無の力で<TARGET>の概念を消去している！',
-        '<TARGET>の存在概念が虚無に侵食され、アイデンティティが失われていく...'
+        '{boss}は虚無の力で{player}の概念を消去している！',
+        '{player}の存在概念が虚無に侵食され、アイデンティティが失われていく...'
     ],
     damageFormula: (user: Boss) => user.attackPower * 2.0,
     statusEffect: StatusEffectType.ConceptSeal,
@@ -475,8 +475,8 @@ explorerLevelRequired: 10
     description: 'プレイヤーの存在そのものを否定する',
     messages: [
         '「お前など、最初から存在しなかった...」',
-        '<USER>は<TARGET>の存在そのものを虚無の力で否定する！',
-        '<TARGET>の存在が徐々に薄れ、現実から消失していく...'
+        '{boss}は{player}の存在そのものを虚無の力で否定する！',
+        '{player}の存在が徐々に薄れ、現実から消失していく...'
     ],
     damageFormula: (user: Boss) => user.attackPower * 2.4,
     statusEffect: StatusEffectType.ExistenceFade,
@@ -491,11 +491,11 @@ explorerLevelRequired: 10
 // finishingMove の実装
 voidSovereignData.finishingMove = function(): string[] {
     return [
-        '虚無の王ヴォイドは<TARGET>の存在を完全に虚無化した！',
+        '虚無の王ヴォイドは{player}の存在を完全に虚無化した！',
         '「すべては虚無に帰る...これが真理だ」',
-        '<TARGET>の存在概念が段階的に消去され、虚無の一部として同化されていく！',
-        '非存在の領域で永遠に漂う<TARGET>...存在していたという記録さえも消え去った',
-        '虚無の静寂が支配する中、<TARGET>は『存在しなかった』という新たな状態を受け入れることになった...'
+        '{player}の存在概念が段階的に消去され、虚無の一部として同化されていく！',
+        '非存在の領域で永遠に漂う{player}...存在していたという記録さえも消え去った',
+        '虚無の静寂が支配する中、{player}は『存在しなかった』という新たな状態を受け入れることになった...'
     ];
 };
 ```
@@ -509,8 +509,8 @@ voidSovereignData.finishingMove = function(): string[] {
     description: '同化した存在の記録を段階的に消去し続ける',
     messages: [
         '「記録の消去を継続...完全な非存在まであと少しだ」',
-        '<USER>は<TARGET>の存在記録を継続的に消去している...',
-        '<TARGET>は虚無の王により段階的に存在記録を消され続けている'
+        '{boss}は{player}の存在記録を継続的に消去している...',
+        '{player}は虚無の王により段階的に存在記録を消され続けている'
     ],
     statusEffect: StatusEffectType.NonExistence,
     statusChance: 1.0,
@@ -528,8 +528,8 @@ voidSovereignData.finishingMove = function(): string[] {
     description: '同化対象の虚無濃度を最適化し続ける',
     messages: [
         '「虚無濃度を調整中...より完璧な非存在へと導こう」',
-        '<USER>は<TARGET>の虚無濃度を細かく調整している！',
-        '<TARGET>は虚無の王による精密な濃度調整により、より純粋な非存在状態へと変化し続けている...'
+        '{boss}は{player}の虚無濃度を細かく調整している！',
+        '{player}は虚無の王による精密な濃度調整により、より純粋な非存在状態へと変化し続けている...'
     ],
     statusEffect: StatusEffectType.VoidErosion,
     statusChance: 0.90,

--- a/docs/drafts/prompt-history.md
+++ b/docs/drafts/prompt-history.md
@@ -557,7 +557,7 @@ Player と Boss の共通処理部分をまとめた基底クラス Actor を作
   - `target`: 対象 (自分自身か、敵か)
   - `mpCost`: マナ消費量
   - `message`: 行動時のメッセージ (リストで複数行のメッセージを指定可能)
-    - メッセージはフォーマット指定可能 (例: `<USER>は<TARGET>に<ACTION>を使った！`)
+    - メッセージはフォーマット指定可能 (例: `{boss}は{player}にスキルを使った！`)
   - `repeatCount`: 繰り返し回数 (通常は1。2以上で「命中判定→ダメージ→特殊効果」の処理を繰り返す) 省略時は 1
   - `accuracy`: 成功率 (0.0 - 1.0) 。失敗時はダメージや特殊効果は発生しない
   - `accuracyType`: 成功率計算タイプ (`fixed`:固定、 または `evade`: 使用者の命中補正と対象の回避率を参照)
@@ -583,7 +583,7 @@ Player と Boss の共通処理部分をまとめた基底クラス Actor を作
   - description: "通常攻撃"
   - target: 'enemy'
   - mpCost: 0
-  - message: ["<USER>の攻撃！"]
+  - message: ["{boss}の攻撃！"]
   - accuracy: 1.0
   - accuracyType: 'evade'
   - damageParameter: 

--- a/src/game/data/bosses/aqua-serpent.ts
+++ b/src/game/data/bosses/aqua-serpent.ts
@@ -46,8 +46,8 @@ const aquaSerpentActions: BossAction[] = [
         description: '海水を操り巨大な水の檻を作成',
         messages: [
             '「シャアアアアアア...」',
-            '<USER>の体が青白く光り、海水が天高く舞い上がる！',
-            '巨大な水の檻が<TARGET>を包み込み、深海の圧力で押し潰そうとする！'
+            '{boss}の体が青白く光り、海水が天高く舞い上がる！',
+            '巨大な水の檻が{player}を包み込み、深海の圧力で押し潰そうとする！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 2.25,
         weight: 5,
@@ -70,8 +70,8 @@ const aquaSerpentActions: BossAction[] = [
         description: '長い体でプレイヤーを巻き付け拘束',
         messages: [
             '「シャアアア...」',
-            '<USER>が長い体を<TARGET>に巻き付けてきた！',
-            '<TARGET>は海蛇の抱擁に捕らわれてしまった...'
+            '{boss}が長い体を{player}に巻き付けてきた！',
+            '{player}は海蛇の抱擁に捕らわれてしまった...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.9,
         weight: 8,
@@ -86,7 +86,7 @@ const aquaSerpentActions: BossAction[] = [
         description: '拘束中の獲物をキスして体力を吸収',
         messages: [
             '「シャアアア...」',
-            '<USER>が<TARGET>を口づけで包み込み、体力を吸収している...'
+            '{boss}が{player}を口づけで包み込み、体力を吸収している...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.4,
         weight: 40,
@@ -100,7 +100,7 @@ const aquaSerpentActions: BossAction[] = [
         description: '拘束中の獲物を体で締めつける',
         messages: [
             '「シャアアア...」',
-            '<USER>が<TARGET>をゆっくりと締めつけている...'
+            '{boss}が{player}をゆっくりと締めつけている...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         weight: 35,
@@ -113,8 +113,8 @@ const aquaSerpentActions: BossAction[] = [
         description: '体内で津波のような胃液を放出',
         messages: [
             '「シャアアアア...」',
-            '<USER>の体内で激しい胃液の嵐が巻き起こる！',
-            '<TARGET>の最大HPが吸収されていく...'
+            '{boss}の体内で激しい胃液の嵐が巻き起こる！',
+            '{player}の最大HPが吸収されていく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.1,
         weight: 25,
@@ -127,8 +127,8 @@ const aquaSerpentActions: BossAction[] = [
         description: '体内の壁が収縮してプレイヤーを押し流す',
         messages: [
             '「シャアアア...」',
-            '<USER>の体内の壁が<TARGET>を奥へと押し流している...',
-            '<TARGET>の最大HPが吸収されていく...'
+            '{boss}の体内の壁が{player}を奥へと押し流している...',
+            '{player}の最大HPが吸収されていく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.25,
         weight: 25,
@@ -141,7 +141,7 @@ const aquaSerpentActions: BossAction[] = [
         description: '体内の光が強くなりプレイヤーを幻惑',
         messages: [
             '「シャアアア...」',
-            '<USER>の体内で神秘的な光が強くなり、<TARGET>を幻惑している...'
+            '{boss}の体内で神秘的な光が強くなり、{player}を幻惑している...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.75,
         weight: 20,
@@ -155,8 +155,8 @@ const aquaSerpentActions: BossAction[] = [
         description: '体内で大量の生命力を吸収',
         messages: [
             '「シャアアアア...」',
-            '<USER>の体内で巨大な渦が発生し、<TARGET>の生命力を激しく吸収している！',
-            '<TARGET>の最大HPが大幅に吸収されていく...'
+            '{boss}の体内で巨大な渦が発生し、{player}の生命力を激しく吸収している！',
+            '{player}の最大HPが大幅に吸収されていく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.75,
         weight: 10,
@@ -169,7 +169,7 @@ const aquaSerpentActions: BossAction[] = [
             // 30% chance to release player after this attack
             if (Math.random() < 0.3) {
                 player.statusEffects.removeEffect(StatusEffectType.Eaten);
-                return ['<TARGET>は激しい渦に巻き込まれ、<USER>の口から吐き出された！'];
+                return ['{player}は激しい渦に巻き込まれ、{boss}の口から吐き出された！'];
             }
             return [];
         }
@@ -237,9 +237,9 @@ export const aquaSerpentData: BossData = {
                     description: '尻尾まで運ばれた獲物を再び口に運んで飲み込む',
                     messages: [
                         '「シャアアア...」',
-                        '<USER>が<TARGET>を尻尾から吐き出した！',
-                        'しかし、すぐに大きな口で<TARGET>を咥え、再び飲み込んでいく！',
-                        '<TARGET>は再び透明な体内に閉じ込められてしまった...'
+                        '{boss}が{player}を尻尾から吐き出した！',
+                        'しかし、すぐに大きな口で{player}を咥え、再び飲み込んでいく！',
+                        '{player}は再び透明な体内に閉じ込められてしまった...'
                     ],
                     weight: 1
                 };
@@ -260,7 +260,7 @@ export const aquaSerpentData: BossData = {
                     name: '胃液でゆっくり洗われる',
                     description: '体内で胃液にゆっくりと洗われ続ける',
                     messages: [
-                        '<USER>の体内で<TARGET>がゆっくりと胃液に洗われている...',
+                        '{boss}の体内で{player}がゆっくりと胃液に洗われている...',
                         '透明な体内から外の深海が見える...'
                     ],
                     weight: 1
@@ -271,8 +271,8 @@ export const aquaSerpentData: BossData = {
                     name: '激しい蠕動運動でさらに奥へ',
                     description: '体内の筋肉が収縮して更に奥へ運ばれる',
                     messages: [
-                        '<USER>の体内で激しい蠕動運動が起こり、<TARGET>を更に奥へと運んでいる...',
-                        '<TARGET>は抵抗することができない...'
+                        '{boss}の体内で激しい蠕動運動が起こり、{player}を更に奥へと運んでいる...',
+                        '{player}は抵抗することができない...'
                     ],
                     weight: 1
                 },
@@ -282,7 +282,7 @@ export const aquaSerpentData: BossData = {
                     name: 'マッサージされながら深海を眺める',
                     description: '体内でマッサージされながら透明な体内から深海を眺める',
                     messages: [
-                        '<USER>の体内で<TARGET>が優しくマッサージされている...',
+                        '{boss}の体内で{player}が優しくマッサージされている...',
                         '透明な体内から美しい深海の光景が見える...'
                     ],
                     weight: 1
@@ -293,8 +293,8 @@ export const aquaSerpentData: BossData = {
                     name: '体内で渦を起こされてぐるぐる',
                     description: '体内で渦を起こされて目を回す',
                     messages: [
-                        '<USER>の体内で激しい渦が起こり、<TARGET>をぐるぐると回転させている...',
-                        '<TARGET>は目を回して意識が朦朧としている...'
+                        '{boss}の体内で激しい渦が起こり、{player}をぐるぐると回転させている...',
+                        '{player}は目を回して意識が朦朧としている...'
                     ],
                     weight: 1
                 }
@@ -331,8 +331,8 @@ export const aquaSerpentData: BossData = {
                         description: '拘束した獲物を丸呑みする',
                         messages: [
                             '「シャアアア...」',
-                            '<USER>が大きな口を開け、<TARGET>をゆっくりと丸呑みにする！',
-                            '<TARGET>は透明な体内に閉じ込められてしまった...'
+                            '{boss}が大きな口を開け、{player}をゆっくりと丸呑みにする！',
+                            '{player}は透明な体内に閉じ込められてしまった...'
                         ],
                         weight: 1
                     };
@@ -348,7 +348,7 @@ export const aquaSerpentData: BossData = {
                         description: '長い体で獲物を拘束する',
                         messages: [
                             '「シャアアア...」',
-                            '<USER>が長い体を<TARGET>に巻き付けてきた！'
+                            '{boss}が長い体を{player}に巻き付けてきた！'
                         ],
                         weight: 1
                     };
@@ -360,8 +360,8 @@ export const aquaSerpentData: BossData = {
                         description: '獲物を丸呑みする',
                         messages: [
                             '「シャアアア...」',
-                            '<USER>が大きな口を開け、<TARGET>をゆっくりと丸呑みにする！',
-                            '<TARGET>は透明な体内に閉じ込められてしまった...'
+                            '{boss}が大きな口を開け、{player}をゆっくりと丸呑みにする！',
+                            '{player}は透明な体内に閉じ込められてしまった...'
                         ],
                         weight: 1
                     };
@@ -439,8 +439,8 @@ export const aquaSerpentData: BossData = {
 aquaSerpentData.finishingMove = function() {
     return [
         '「シャアアア...」',
-        '<USER>は<TARGET>を体内の奥深くへと運んでいく...',
-        '<TARGET>はアクアサーペントの透明な体内で、美しい深海の光景を眺めながら永遠に過ごすことになった...'
+        '{boss}は{player}を体内の奥深くへと運んでいく...',
+        '{player}はアクアサーペントの透明な体内で、美しい深海の光景を眺めながら永遠に過ごすことになった...'
     ];
 };
 

--- a/src/game/data/bosses/bat-vampire.ts
+++ b/src/game/data/bosses/bat-vampire.ts
@@ -33,7 +33,7 @@ const batVampireActions: BossAction[] = [
         hitRate: 0.85,
         weight: 15,
         playerStateCondition: 'normal',
-        messages: ['<USER>は無数の子コウモリを放った！']
+        messages: ['{boss}は無数の子コウモリを放った！']
     },
     {
         id: 'shadow-bullet',
@@ -46,7 +46,7 @@ const batVampireActions: BossAction[] = [
         hitRate: 0.60,
         weight: 15,
         playerStateCondition: 'normal',
-        messages: ['<USER>は影の弾を放った！']
+        messages: ['{boss}は影の弾を放った！']
     },
     {
         id: 'vampire-hold',
@@ -55,7 +55,7 @@ const batVampireActions: BossAction[] = [
         description: '強力な握力で対象を拘束する',
         weight: 10,
         playerStateCondition: 'normal',
-        messages: ['<USER>は<TARGET>を掴み上げる！']
+        messages: ['{boss}は{player}を掴み上げる！']
     },
 
     // 拘束中専用攻撃
@@ -69,7 +69,7 @@ const batVampireActions: BossAction[] = [
         statusChance: 0.60,
         weight: 30,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>に噛みつき、生気を吸い取る！', '<TARGET>の力と魔力が奪われていく...']
+        messages: ['{boss}は{player}に噛みつき、生気を吸い取る！', '{player}の力と魔力が奪われていく...']
     },
     {
         id: 'vampire-kiss',
@@ -81,7 +81,7 @@ const batVampireActions: BossAction[] = [
         statusChance: 0.90,
         weight: 25,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>に深いキスをした...']
+        messages: ['{boss}は{player}に深いキスをした...']
     },
     {
         id: 'minion-hypnosis',
@@ -110,9 +110,9 @@ const batVampireActions: BossAction[] = [
             return [];
         },
         messages: [
-            '<USER>の瞳が妖艶に光り始める...',
+            '{boss}の瞳が妖艶に光り始める...',
             '「我が眷属となり、永遠の眠りにつきなさい...」',
-            '<TARGET>は<USER>の催眠術にかかり、深い眠りに落ちた！'
+            '{player}は{boss}の催眠術にかかり、深い眠りに落ちた！'
         ]
     },
 
@@ -125,7 +125,7 @@ const batVampireActions: BossAction[] = [
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         weight: 50,
         playerStateCondition: 'ko',
-        messages: ['<USER>は<TARGET>に噛みつき、生命力そのものを吸い取る...', `生命力を吸われた<TARGET>の体が縮小していく！`]
+        messages: ['{boss}は{player}に噛みつき、生命力そのものを吸い取る...', `生命力を吸われた{player}の体が縮小していく！`]
     },
 
     // とどめ攻撃（プレイヤーがDoomed状態時）
@@ -137,10 +137,10 @@ const batVampireActions: BossAction[] = [
         weight: 100,
         playerStateCondition: 'defeated',
         messages: [
-            '<TARGET>の生気は完全に吸い尽くされ、体が小さくなってしまった...',
-            '<USER>は小さくなった<TARGET>を優しく抱き上げると、そのまま口の中に運んでいく...',
+            '{player}の生気は完全に吸い尽くされ、体が小さくなってしまった...',
+            '{boss}は小さくなった{player}を優しく抱き上げると、そのまま口の中に運んでいく...',
             '「ふふ...君のような美しい獲物は、永遠に私の体内で愛でてあげよう」',
-            '<TARGET>は<USER>の体内でペットのように飼われることになった...'
+            '{player}は{boss}の体内でペットのように飼われることになった...'
         ],
         onUse: (_boss: Boss, player: Player) => {
             // 再起不能状態を解除 (TODO: Dead 状態付与時に自動解除したい)
@@ -164,8 +164,8 @@ const batVampireActions: BossAction[] = [
         weight: 25,
         playerStateCondition: 'defeated',
         messages: [
-            '<USER>の胃袋にある吸収器官が<TARGET>をやさしく包み込む',
-            '<TARGET>の生気がゆっくりと吸い取られていく...'
+            '{boss}の胃袋にある吸収器官が{player}をやさしく包み込む',
+            '{player}の生気がゆっくりと吸い取られていく...'
         ]
     },
     {
@@ -178,8 +178,8 @@ const batVampireActions: BossAction[] = [
         statusEffect: StatusEffectType.Charm,
         statusChance: 0.8,
         messages: [
-            '<USER>の体内で柔らかい触手が<TARGET>を優しく愛撫する',
-            '<TARGET>は心地よい感覚に包まれながら生気を奪われていく...'
+            '{boss}の体内で柔らかい触手が{player}を優しく愛撫する',
+            '{player}は心地よい感覚に包まれながら生気を奪われていく...'
         ]
     },
     {
@@ -192,8 +192,8 @@ const batVampireActions: BossAction[] = [
         statusEffect: StatusEffectType.Fascination,
         statusChance: 0.9,
         messages: [
-            '<USER>の胃袋が<TARGET>を包み込むようにマッサージする',
-            '<TARGET>は至福の感覚に魅了されてしまう...'
+            '{boss}の胃袋が{player}を包み込むようにマッサージする',
+            '{player}は至福の感覚に魅了されてしまう...'
         ]
     },
     {
@@ -206,8 +206,8 @@ const batVampireActions: BossAction[] = [
         statusEffect: StatusEffectType.Bliss,
         statusChance: 0.7,
         messages: [
-            '<USER>の体内で無数の細かい器官が<TARGET>をくすぐり始める',
-            '<TARGET>は笑いと快感で意識が朦朧としてくる...'
+            '{boss}の体内で無数の細かい器官が{player}をくすぐり始める',
+            '{player}は笑いと快感で意識が朦朧としてくる...'
         ]
     },
     {
@@ -219,9 +219,9 @@ const batVampireActions: BossAction[] = [
         playerStateCondition: 'defeated',
         messages: [
             '「さあ、私も食事をしようか...」',
-            '<USER>は大きなパンをかじっては飲み込み、もう一つの胃袋に送り込む！',
-            '<TARGET>が収められた胃袋の外側から、くぐもった蠕動の音と、食べ物が消化されていく轟音が響き渡る...',
-            '<TARGET>は別の胃袋に入れられた食べ物の末路を想像し不安になる...'
+            '{boss}は大きなパンをかじっては飲み込み、もう一つの胃袋に送り込む！',
+            '{player}が収められた胃袋の外側から、くぐもった蠕動の音と、食べ物が消化されていく轟音が響き渡る...',
+            '{player}は別の胃袋に入れられた食べ物の末路を想像し不安になる...'
         ]
     },
     {
@@ -233,8 +233,8 @@ const batVampireActions: BossAction[] = [
         playerStateCondition: 'defeated',
         messages: [
             '「君にも栄養を分けてあげよう...」',
-            '<USER>の体内で管のような器官が<TARGET>の口元に伸びてくる！',
-            '<TARGET>は管のような器官を口に入れられ、どろどろになった食べ物を飲まされ続ける...',
+            '{boss}の体内で管のような器官が{player}の口元に伸びてくる！',
+            '{player}は管のような器官を口に入れられ、どろどろになった食べ物を飲まされ続ける...',
             '「よい子だ...これで君はずっと私の大切な宝物でいられる」'
         ]
     }

--- a/src/game/data/bosses/clean-master.ts
+++ b/src/game/data/bosses/clean-master.ts
@@ -10,7 +10,7 @@ const cleanMasterActions: BossAction[] = [
         description: 'やさしく吸い込んで汚れを取る',
         messages: [
             'お掃除開始〜♪',
-            '<USER>は小さな吸引で<TARGET>の汚れを取ろうとする！'
+            '{boss}は小さな吸引で{player}の汚れを取ろうとする！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.7,
         hitRate: 0.95,
@@ -26,7 +26,7 @@ const cleanMasterActions: BossAction[] = [
         description: 'パワフルに吸い込んで汚れを根こそぎ取る',
         messages: [
             'がんばって吸い込むよ〜♪',
-            '<USER>は強力な吸引で<TARGET>を吸い寄せる！'
+            '{boss}は強力な吸引で{player}を吸い寄せる！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         hitRate: 0.8,
@@ -42,7 +42,7 @@ const cleanMasterActions: BossAction[] = [
         description: 'ブラシでサッサと埃を払う',
         messages: [
             'ほこりほこり〜♪',
-            '<USER>は回転ブラシで<TARGET>の埃を払う！'
+            '{boss}は回転ブラシで{player}の埃を払う！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.8,
         hitRate: 0.9,
@@ -56,7 +56,7 @@ const cleanMasterActions: BossAction[] = [
         description: 'お掃除アームで優しく捕まえる',
         messages: [
             'つかまえた〜♪',
-            '<USER>は清掃アームで<TARGET>を優しく捕まえる！'
+            '{boss}は清掃アームで{player}を優しく捕まえる！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.5,
         weight: 15,
@@ -71,7 +71,7 @@ const cleanMasterActions: BossAction[] = [
         description: 'お掃除用の泡をシューッと吹きかける',
         messages: [
             '泡泡スプレー〜♪',
-            '<USER>は<TARGET>に清掃用の泡をスプレーする！'
+            '{boss}は{player}に清掃用の泡をスプレーする！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.4,
         hitRate: 0.95,
@@ -90,7 +90,7 @@ const cleanMasterActionsRestrained: BossAction[] = [
         description: '捕まえた相手をやさしくブラシで洗う',
         messages: [
             'ふかふかブラシ〜♪',
-            '<USER>は<TARGET>をやさしくブラシで洗っている！'
+            '{boss}は{player}をやさしくブラシで洗っている！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.25,
         weight: 30
@@ -102,7 +102,7 @@ const cleanMasterActionsRestrained: BossAction[] = [
         description: '汚れをしっかり落とすために高圧水で洗う',
         messages: [
             'まだ汚れてるよ〜、もっと洗わなくちゃ♪',
-            '<USER>は<TARGET>をしっかりと洗濯している！'
+            '{boss}は{player}をしっかりと洗濯している！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.7,
         weight: 25,
@@ -116,7 +116,7 @@ const cleanMasterActionsRestrained: BossAction[] = [
         description: '泡でもみもみ洗って汚れを落とす',
         messages: [
             'もみもみ泡泡〜♪',
-            '<USER>は<TARGET>に泡を吹きかけ、アームで優しくもみ洗いしている！'
+            '{boss}は{player}に泡を吹きかけ、アームで優しくもみ洗いしている！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         weight: 20,
@@ -134,7 +134,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         description: '体内で完全な洗浄サイクルを実行',
         messages: [
             'ぐるぐる洗濯モード〜♪',
-            '<USER>は体内で<TARGET>を洗浄サイクルにかけている！'
+            '{boss}は体内で{player}を洗浄サイクルにかけている！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.8,
         weight: 25,
@@ -148,7 +148,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         description: '遠心分離で水分を飛ばす',
         messages: [
             'くるくる脱水〜♪',
-            '<USER>は<TARGET>を遠心分離で脱水している！'
+            '{boss}は{player}を遠心分離で脱水している！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 2.0,
         weight: 20,
@@ -162,7 +162,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         description: 'ほかほかの温風で乾燥させる',
         messages: [
             'ほかほか温風〜♪',
-            '<USER>は<TARGET>を温風で乾燥させている！'
+            '{boss}は{player}を温風で乾燥させている！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.3,
         weight: 25,
@@ -176,7 +176,7 @@ const cleanMasterActionsEaten: BossAction[] = [
         description: '最後の仕上げでアイロンがけ',
         messages: [
             'アイロンでしわしわ取る〜♪',
-            '<USER>は<TARGET>をアイロンで仕上げている！'
+            '{boss}は{player}をアイロンで仕上げている！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.7,
         weight: 15,
@@ -189,9 +189,9 @@ const cleanMasterActionsEaten: BossAction[] = [
         name: '完璧チェック',
         description: '汚れが残ってないかチェック',
         messages: [
-            '<USER>は<TARGET>をくまなくチェックしている...',
+            '{boss}は{player}をくまなくチェックしている...',
             'うーん、まだ汚れてるかも〜？もう一度お掃除しなくちゃ♪',
-            '<USER>は<TARGET>をキレイにするためにもう一度洗浄を始める！'
+            '{boss}は{player}をキレイにするためにもう一度洗浄を始める！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.2,
         weight: 20
@@ -277,7 +277,7 @@ export const cleanMasterData: BossData = {
                     description: '完璧になるまで永続的に清掃し続ける',
                     messages: [
                         'ずっとお掃除してあげるからね〜♪',
-                        '<USER>は<TARGET>を永続的に清掃し続けている...',
+                        '{boss}は{player}を永続的に清掃し続けている...',
                         'でも、どんなに洗っても「まだ汚れてる」と言い続ける...'
                     ],
                     weight: 1
@@ -289,8 +289,8 @@ export const cleanMasterData: BossData = {
                     description: '99%では満足せず、100%完璧を目指す',
                     messages: [
                         'あっ！まだ汚れが...もう1回〜♪',
-                        '<USER>は<TARGET>の見えない汚れを発見してしまった...',
-                        '完璧主義の<USER>は決して満足しない...'
+                        '{boss}は{player}の見えない汚れを発見してしまった...',
+                        '完璧主義の{boss}は決して満足しない...'
                     ],
                     weight: 1
                 },
@@ -301,7 +301,7 @@ export const cleanMasterData: BossData = {
                     description: '愛情を込めてお掃除し続ける',
                     messages: [
                         'だいすきだから、きれいにしてあげる〜♪',
-                        '<USER>は<TARGET>を愛情込めて清掃している...',
+                        '{boss}は{player}を愛情込めて清掃している...',
                         'でも、愛情が深すぎて止まらない...'
                     ],
                     weight: 1
@@ -348,7 +348,7 @@ export const cleanMasterData: BossData = {
                         description: '体内洗浄槽で完全清掃する',
                         messages: [
                             'やったぁ〜！お洗濯タイム♪',
-                            '<USER>は清掃アームで<TARGET>を体内洗浄槽に放り込む！'
+                            '{boss}は清掃アームで{player}を体内洗浄槽に放り込む！'
                         ],
                         weight: 1
                     };
@@ -364,7 +364,7 @@ export const cleanMasterData: BossData = {
                         description: '清掃アームで捕まえる',
                         messages: [
                             'つかまえた〜♪',
-                            '<USER>は清掃アームで<TARGET>を捕まえる！'
+                            '{boss}は清掃アームで{player}を捕まえる！'
                         ],
                         weight: 1
                     };
@@ -376,7 +376,7 @@ export const cleanMasterData: BossData = {
                         description: '体内洗浄槽で完全清掃する',
                         messages: [
                             'やったぁ〜！お洗濯タイム♪',
-                            '<USER>は<TARGET>を直接体内洗浄槽に吸い込む！'
+                            '{boss}は{player}を直接体内洗浄槽に吸い込む！'
                         ],
                         weight: 1
                     };
@@ -458,10 +458,10 @@ export const cleanMasterData: BossData = {
 // 特殊な勝利条件: 完璧主義で永続清掃
 cleanMasterData.finishingMove = function(): string[] {
     return [
-        'クリーンマスターは<TARGET>を完璧に清掃した！',
+        'クリーンマスターは{player}を完璧に清掃した！',
         'でも、完璧主義のクリーンマスターは「まだ汚れてるかも...」と心配している...',
-        '<TARGET>はクリーンマスターの体内洗浄槽に永続的に保管された！',
-        'クリーンマスターは毎日<TARGET>を洗い続け、「今日もお掃除がんばるよ〜♪」と楽しそうに呟いている...'
+        '{player}はクリーンマスターの体内洗浄槽に永続的に保管された！',
+        'クリーンマスターは毎日{player}を洗い続け、「今日もお掃除がんばるよ〜♪」と楽しそうに呟いている...'
     ];
 };
 

--- a/src/game/data/bosses/dark-ghost.ts
+++ b/src/game/data/bosses/dark-ghost.ts
@@ -48,7 +48,7 @@ const darkGhostActions: BossAction[] = [
         description: '影の触手で対象を拘束する',
         messages: [
             '「もっとじっくり見たいナ！」',
-            '<USER>は影の触手で<TARGET>を捕らえようとしてきた！'
+            '{boss}は影の触手で{player}を捕らえようとしてきた！'
         ],
         weight: 15,
         hitRate: 0.9,
@@ -65,7 +65,7 @@ const darkGhostActions: BossAction[] = [
         description: '拘束中の対象を影の舌でなめまわす（与えたダメージ分回復）',
         messages: [
             '「味見しちゃうヨ...」',
-            '<USER>は舌で<TARGET>をなめまわしてきた！'
+            '{boss}は舌で{player}をなめまわしてきた！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.3,
         weight: 30,
@@ -114,8 +114,8 @@ export const darkGhostData: BossData = {
                     description: '魂だけになった獲物からエネルギーを吸い続ける',
                     messages: [
                         '「ケケケ...」',
-                        '<USER>が<TARGET>の魂からエネルギーを吸い取っている...',
-                        '<TARGET>の魂は<USER>の中で力を失っていく...'
+                        '{boss}が{player}の魂からエネルギーを吸い取っている...',
+                        '{player}の魂は{boss}の中で力を失っていく...'
                     ],
                     statusEffect: StatusEffectType.Exhausted,
                     weight: 1
@@ -127,8 +127,8 @@ export const darkGhostData: BossData = {
                     description: '魂を操作して獲物を支配し続ける',
                     messages: [
                         '「フフフ...」',
-                        '<USER>が<TARGET>の魂を操縦している...',
-                        '<TARGET>の意識は<USER>に支配されている...'
+                        '{boss}が{player}の魂を操縦している...',
+                        '{player}の意識は{boss}に支配されている...'
                     ],
                     statusEffect: StatusEffectType.Charm,
                     weight: 1
@@ -140,8 +140,8 @@ export const darkGhostData: BossData = {
                     description: '魂に毒を流し込み続ける',
                     messages: [
                         '「ケケケ...」',
-                        '<USER>が<TARGET>の魂に毒を流し込んでいる...',
-                        '<TARGET>の魂は徐々に汚染されていく...'
+                        '{boss}が{player}の魂に毒を流し込んでいる...',
+                        '{player}の魂は徐々に汚染されていく...'
                     ],
                     statusEffect: StatusEffectType.Poison,
                     weight: 1
@@ -153,8 +153,8 @@ export const darkGhostData: BossData = {
                     description: '魂の動きを鈍らせ続ける',
                     messages: [
                         '「フフフ...」',
-                        '<USER>が<TARGET>の魂の動きを鈍らせている...',
-                        '<TARGET>の魂は重く沈んでいく...'
+                        '{boss}が{player}の魂の動きを鈍らせている...',
+                        '{player}の魂は重く沈んでいく...'
                     ],
                     statusEffect: StatusEffectType.Slow,
                     weight: 1
@@ -166,8 +166,8 @@ export const darkGhostData: BossData = {
                     description: '魂を監視し続けて逃げられないようにする',
                     messages: [
                         '「ケケケ...」',
-                        '<USER>が<TARGET>の魂を監視している...',
-                        '<TARGET>の魂は<USER>の視線から逃れられない...'
+                        '{boss}が{player}の魂を監視している...',
+                        '{player}の魂は{boss}の視線から逃れられない...'
                     ],
                     statusEffect: StatusEffectType.Paralysis,
                     weight: 1
@@ -187,7 +187,7 @@ export const darkGhostData: BossData = {
                     description: '体内にいる獲物の生命エネルギーを吸収する',
                     messages: [
                         '「キミのタマシイ、おいしいネ...」',
-                        '<USER>は体内の<TARGET>の魂からエネルギーを吸い取っている...'
+                        '{boss}は体内の{player}の魂からエネルギーを吸い取っている...'
                     ],
                     weight: 30
                 },
@@ -199,7 +199,7 @@ export const darkGhostData: BossData = {
                     description: '体内にいる獲物の魂を影の触手で引き抜こうとする',
                     messages: [
                         '「ユックリと引き抜いてあげるヨ...」',
-                        '<USER>の胃袋から影の触手が伸び、<TARGET>の魂を引き抜こうとする...'
+                        '{boss}の胃袋から影の触手が伸び、{player}の魂を引き抜こうとする...'
                     ],
                     weight: 25
                 },
@@ -211,7 +211,7 @@ export const darkGhostData: BossData = {
                     description: '体内にいる獲物を粘液で包み込み、動きを封じる',
                     messages: [
                         '「ネバネバ粘液から抜け出せるかナ？」',
-                        '<USER>の胃袋が大量の粘液を出し、<TARGET>を包み込む...'
+                        '{boss}の胃袋が大量の粘液を出し、{player}を包み込む...'
                     ],
                     statusEffect: StatusEffectType.Slimed,
                     weight: 25
@@ -224,7 +224,7 @@ export const darkGhostData: BossData = {
                     description: '絶望的な言葉で心を折り恐怖を植え付ける',
                     messages: [
                         '「もう誰も助けに来ないヨ...」',
-                        '<USER>が<TARGET>の心に絶望を囁いている...'
+                        '{boss}が{player}の心に絶望を囁いている...'
                     ],
                     statusEffect: StatusEffectType.Fear,
                     statusChance: 0.8,
@@ -238,7 +238,7 @@ export const darkGhostData: BossData = {
                     description: '記憶を蝕みスキルの記憶を奪う',
                     messages: [
                         '「難しいことなんて忘れて、楽にしてあげるネ...」',
-                        '<USER>が<TARGET>の記憶を侵食している...'
+                        '{boss}が{player}の記憶を侵食している...'
                     ],
                     statusEffect: StatusEffectType.Oblivion,
                     weight: 15,
@@ -289,7 +289,7 @@ export const darkGhostData: BossData = {
                         description: '魂を吸い取るために対象を丸呑みにする',
                         messages: [
                             '「イタダキマース！」',
-                            '<USER>は大きな口を開け、<TARGET>を吸い込む！'
+                            '{boss}は大きな口を開け、{player}を吸い込む！'
                         ],
                         weight: 1
                     };
@@ -305,7 +305,7 @@ export const darkGhostData: BossData = {
                         description: '対象を影の触手で拘束する',
                         messages: [
                             '「もっとじっくり見たいナ！」',
-                            '<USER>は影の触手で<TARGET>を捕らえようとしてきた！'
+                            '{boss}は影の触手で{player}を捕らえようとしてきた！'
                         ],
                         weight: 1
                     };
@@ -317,7 +317,7 @@ export const darkGhostData: BossData = {
                         description: '魂を吸い取るために対象を丸呑みにする',
                         messages: [
                             '「イタダキマース！」',
-                            '<USER>は大きな口を開け、<TARGET>を吸い込む！'
+                            '{boss}は大きな口を開け、{player}を吸い込む！'
                         ],
                         weight: 1
                     };
@@ -377,8 +377,8 @@ export const darkGhostData: BossData = {
 // Add finishing move for doomed player
 darkGhostData.finishingMove = function() {
     return [
-        '<USER>は<TARGET>の魂ごと吸い取り、<USER>の体に取り込む！',
-        '<TARGET>の魂は<USER>の中に閉じ込められ、満足するまで生命エネルギーを吸われ続けることになった...'
+        '{boss}は{player}の魂ごと吸い取り、{boss}の体に取り込む！',
+        '{player}の魂は{boss}の中に閉じ込められ、満足するまで生命エネルギーを吸われ続けることになった...'
     ];
 };
 

--- a/src/game/data/bosses/dream-demon.ts
+++ b/src/game/data/bosses/dream-demon.ts
@@ -10,7 +10,7 @@ const dreamDemonActions: BossAction[] = [
         description: '小さな触手で軽く攻撃',
         messages: [
             'ちょちょいっと触手攻撃ンメェ〜♪',
-            '<USER>は小さな触手で<TARGET>を軽くペチペチと叩いた！'
+            '{boss}は小さな触手で{player}を軽くペチペチと叩いた！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.8,
         hitRate: 0.95,
@@ -29,8 +29,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 25,
         messages: [
             'あたいの可愛さに見とれちゃいなンメェ〜♪',
-            '<USER>は甘い眼差しで<TARGET>を見つめる...',
-            '<TARGET>の心がとろけそうになる...'
+            '{boss}は甘い眼差しで{player}を見つめる...',
+            '{player}の心がとろけそうになる...'
         ]
     },
     {
@@ -43,8 +43,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 20,
         messages: [
             'きらきら〜な粉をまいちゃうンメェ〜♪',
-            '<USER>は光る粉を撒き散らした！',
-            '<TARGET>の体がしびれていく...'
+            '{boss}は光る粉を撒き散らした！',
+            '{player}の体がしびれていく...'
         ]
     },
     {
@@ -57,8 +57,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 25,
         messages: [
             'あまあま〜な息をふーってしてあげるンメェ〜♪',
-            '<USER>は甘い香りの息を<TARGET>に吹きかけた',
-            '<TARGET>の体が熱くなってきた...'
+            '{boss}は甘い香りの息を{player}に吹きかけた',
+            '{player}の体が熱くなってきた...'
         ]
     },
     {
@@ -71,8 +71,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 20,
         messages: [
             'ねむねむになっちゃえンメェ〜♪',
-            '<USER>は催眠術をかけてきた',
-            '<TARGET>のまぶたが重くなってきた...'
+            '{boss}は催眠術をかけてきた',
+            '{player}のまぶたが重くなってきた...'
         ]
     },
     {
@@ -85,8 +85,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 20,
         messages: [
             'だら〜んってしちゃえンメェ〜♪',
-            '<USER>は呪文を唱えた',
-            '<TARGET>の力が抜けていく...'
+            '{boss}は呪文を唱えた',
+            '{player}の力が抜けていく...'
         ]
     },
     {
@@ -99,8 +99,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 25,
         messages: [
             'きゃぴ〜ん♪ メロメロビーム発射ンメェ〜！',
-            '<USER>はハート型の光線を放った！',
-            '<TARGET>は完全にメロメロになってしまった...'
+            '{boss}はハート型の光線を放った！',
+            '{player}は完全にメロメロになってしまった...'
         ]
     },
     {
@@ -113,8 +113,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 20,
         messages: [
             'ぐるぐる〜って混乱させちゃうンメェ〜♪',
-            '<USER>は不思議な渦を作り出した',
-            '<TARGET>の思考が混乱してきた...'
+            '{boss}は不思議な渦を作り出した',
+            '{player}の思考が混乱してきた...'
         ]
     },
     {
@@ -127,8 +127,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 25,
         messages: [
             'ぽっかぽか〜にしてあげるンメェ〜♪',
-            '<USER>は妖艶な魔法をかけた',
-            '<TARGET>の体が火照ってきた...'
+            '{boss}は妖艶な魔法をかけた',
+            '{player}の体が火照ってきた...'
         ]
     },
     {
@@ -141,8 +141,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 20,
         messages: [
             'きゃ〜ん♪ あたいの悩殺ポーズンメェ〜',
-            '<USER>は急接近し深いべろちゅーをしてきた！',
-            '<TARGET>は完全に悩殺されてしまった...'
+            '{boss}は急接近し深いべろちゅーをしてきた！',
+            '{player}は完全に悩殺されてしまった...'
         ]
     },
     {
@@ -155,8 +155,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 15,
         messages: [
             'まほう使えなくしちゃうンメェ〜♪',
-            '<USER>は封印の呪文を唱えた',
-            '<TARGET>の魔力が封じられた！'
+            '{boss}は封印の呪文を唱えた',
+            '{player}の魔力が封じられた！'
         ]
     },
     {
@@ -169,8 +169,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 15,
         messages: [
             'あまあま〜な快楽に溺れちゃえンメェ〜♪',
-            '<USER>は禁断の呪いをかけた...',
-            '<TARGET>は快楽の波に飲み込まれていく...'
+            '{boss}は禁断の呪いをかけた...',
+            '{player}は快楽の波に飲み込まれていく...'
         ]
     },
     {
@@ -183,8 +183,8 @@ const dreamDemonActions: BossAction[] = [
         weight: 15,
         messages: [
             'えっちな魔法で理性を飛ばしちゃうンメェ〜♪',
-            '<USER>は淫らな魔法を唱えた',
-            '<TARGET>の理性が揺らいでいく...'
+            '{boss}は淫らな魔法を唱えた',
+            '{player}の理性が揺らいでいく...'
         ]
     },
     {
@@ -199,7 +199,7 @@ const dreamDemonActions: BossAction[] = [
             // Use when player has multiple debuffs
             return player.statusEffects.getDebuffLevel() >= 5;
         },
-        messages: ['<USER>は強力な催眠波動を放った！', '<TARGET>の意識が朦朧としてきた...']
+        messages: ['{boss}は強力な催眠波動を放った！', '{player}の意識が朦朧としてきた...']
     },
     {
         id: 'brainwash-beam',
@@ -213,7 +213,7 @@ const dreamDemonActions: BossAction[] = [
             // Use when player is severely debuffed
             return player.statusEffects.getDebuffLevel() >= 7;
         },
-        messages: ['<USER>は邪悪な光線を<TARGET>に向けた...', '<TARGET>の思考が侵食されていく...']
+        messages: ['{boss}は邪悪な光線を{player}に向けた...', '{player}の思考が侵食されていく...']
     },
     {
         id: 'sweet-magic',
@@ -223,7 +223,7 @@ const dreamDemonActions: BossAction[] = [
         statusEffect: StatusEffectType.Sweet,
         statusChance: 0.85,
         weight: 20,
-        messages: ['<USER>は甘い魔法をかけた', '<TARGET>は幸せな気分になった...']
+        messages: ['{boss}は甘い魔法をかけた', '{player}は幸せな気分になった...']
     },
     {
         id: 'melting-magic',
@@ -233,7 +233,7 @@ const dreamDemonActions: BossAction[] = [
         statusEffect: StatusEffectType.Melting,
         statusChance: 0.85,
         weight: 20,
-        messages: ['<USER>はとろける魔法をかけた', '<TARGET>の意識がとろけていく...']
+        messages: ['{boss}はとろける魔法をかけた', '{player}の意識がとろけていく...']
     },
     {
         id: 'euphoria-magic',
@@ -243,7 +243,7 @@ const dreamDemonActions: BossAction[] = [
         statusEffect: StatusEffectType.Euphoria,
         statusChance: 0.80,
         weight: 18,
-        messages: ['<USER>は恍惚の魔法をかけた', '<TARGET>はうっとりとした表情になった...']
+        messages: ['{boss}は恍惚の魔法をかけた', '{player}はうっとりとした表情になった...']
     },
     {
         id: 'fascination-art',
@@ -253,7 +253,7 @@ const dreamDemonActions: BossAction[] = [
         statusEffect: StatusEffectType.Fascination,
         statusChance: 0.85,
         weight: 20,
-        messages: ['<USER>は魅惑の術を唱えた', '<TARGET>は深い魅惑に囚われた...']
+        messages: ['{boss}は魅惑の術を唱えた', '{player}は深い魅惑に囚われた...']
     },
     {
         id: 'bliss-spell',
@@ -263,7 +263,7 @@ const dreamDemonActions: BossAction[] = [
         statusEffect: StatusEffectType.Bliss,
         statusChance: 0.75,
         weight: 15,
-        messages: ['<USER>は至福の呪文を唱えた', '<TARGET>は至福の表情を浮かべた...']
+        messages: ['{boss}は至福の呪文を唱えた', '{player}は至福の表情を浮かべた...']
     },
     {
         id: 'enchantment-technique',
@@ -277,7 +277,7 @@ const dreamDemonActions: BossAction[] = [
             // Use when player has multiple debuffs
             return player.statusEffects.getDebuffLevel() >= 6;
         },
-        messages: ['<USER>は強力な魅了術を発動した', '<TARGET>は完全に魅了されてしまった...']
+        messages: ['{boss}は強力な魅了術を発動した', '{player}は完全に魅了されてしまった...']
     },
     
     // Restraint attacks
@@ -290,7 +290,7 @@ const dreamDemonActions: BossAction[] = [
         hitRate: 0.85,
         messages: [
             'しっぽでぎゅーってしちゃうンメェ〜♪',
-            '<USER>は長い尻尾で<TARGET>を捕らえようとしてきた！'
+            '{boss}は長い尻尾で{player}を捕らえようとしてきた！'
         ],
         canUse: (_boss, player, _turn) => {
             return !player.isRestrained() && !player.isEaten() && Math.random() < 0.4;
@@ -305,7 +305,7 @@ const dreamDemonActions: BossAction[] = [
         hitRate: 0.80,
         messages: [
             'まほうの手でつかまえちゃうンメェ〜♪',
-            '<USER>は魔法の手を伸ばして<TARGET>を掴もうとしてきた！'
+            '{boss}は魔法の手を伸ばして{player}を掴もうとしてきた！'
         ],
         canUse: (_boss, player, _turn) => {
             return !player.isRestrained() && !player.isEaten() && Math.random() < 0.35;
@@ -320,8 +320,8 @@ const dreamDemonActions: BossAction[] = [
         hitRate: 0.90,
         messages: [
             'てれぽーとで背後を取るンメェ〜♪',
-            '<USER>は一瞬姿を消した...',
-            '気づくと<USER>が<TARGET>の背後にいた！'
+            '{boss}は一瞬姿を消した...',
+            '気づくと{boss}が{player}の背後にいた！'
         ],
         canUse: (_boss, player, _turn) => {
             return !player.isRestrained() && !player.isEaten() && Math.random() < 0.3;
@@ -341,8 +341,8 @@ const dreamDemonActions: BossAction[] = [
         playerStateCondition: 'restrained',
         messages: [
             'ちゅ〜♪ あまあまキスしてあげるンメェ〜',
-            '<USER>は<TARGET>に熱いキスをした...',
-            '<TARGET>は完全にとろけてしまった...'
+            '{boss}は{player}に熱いキスをした...',
+            '{player}は完全にとろけてしまった...'
         ]
     },
     {
@@ -357,8 +357,8 @@ const dreamDemonActions: BossAction[] = [
         playerStateCondition: 'restrained',
         messages: [
             'べろべろ〜♪ あまあまにしてやるンメェ〜',
-            '<USER>は大きな舌で<TARGET>をべろべろとなめまわした',
-            '<TARGET>の体が震えている...'
+            '{boss}は大きな舌で{player}をべろべろとなめまわした',
+            '{player}の体が震えている...'
         ]
     },
     {
@@ -373,8 +373,8 @@ const dreamDemonActions: BossAction[] = [
         playerStateCondition: 'restrained',
         messages: [
             'ぺったんぺったん〜♪ 密着攻撃ンメェ〜',
-            '<USER>は<TARGET>に体を密着させてきた',
-            '<TARGET>は誘惑に負けそうになっている...'
+            '{boss}は{player}に体を密着させてきた',
+            '{player}は誘惑に負けそうになっている...'
         ]
     },
     {
@@ -389,8 +389,8 @@ const dreamDemonActions: BossAction[] = [
         playerStateCondition: 'restrained',
         messages: [
             'ゆさゆさ〜♪ あまあまにしてやるンメェ〜',
-            '<USER>は<TARGET>の体をリズミカルに揺さぶった',
-            '<TARGET>は快楽の波に飲み込まれていく...'
+            '{boss}は{player}の体をリズミカルに揺さぶった',
+            '{player}は快楽の波に飲み込まれていく...'
         ]
     },
     
@@ -405,7 +405,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.85,
         weight: 25,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>に激しく体を押し付けてきた', '<TARGET>は息ができないほど密着されている...']
+        messages: ['{boss}は{player}に激しく体を押し付けてきた', '{player}は息ができないほど密着されている...']
     },
     {
         id: 'intense-shaking',
@@ -417,7 +417,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.90,
         weight: 23,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>を激しく揺さぶった', '<TARGET>の理性が揺らいでいく...']
+        messages: ['{boss}は{player}を激しく揺さぶった', '{player}の理性が揺らいでいく...']
     },
     {
         id: 'sensual-movement',
@@ -429,7 +429,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.95,
         weight: 26,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は官能的な動きを見せつけてきた', '<TARGET>は目が離せなくなっている...']
+        messages: ['{boss}は官能的な動きを見せつけてきた', '{player}は目が離せなくなっている...']
     },
     {
         id: 'intense-caress',
@@ -441,7 +441,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.88,
         weight: 24,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>を激しく愛撫してきた', '<TARGET>の感覚がとろけていく...']
+        messages: ['{boss}は{player}を激しく愛撫してきた', '{player}の感覚がとろけていく...']
     },
     {
         id: 'pressure-attack',
@@ -453,7 +453,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.85,
         weight: 22,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>に全体重をかけて圧迫してきた', '<TARGET>は恍惚の表情を浮かべている...']
+        messages: ['{boss}は{player}に全体重をかけて圧迫してきた', '{player}は恍惚の表情を浮かべている...']
     },
     
     // All debuff restraint versions
@@ -467,7 +467,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.98,
         weight: 20,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>を見つめながら強力な魅了をかけた', '<TARGET>の意思が完全に奪われていく...']
+        messages: ['{boss}は{player}を見つめながら強力な魅了をかけた', '{player}の意思が完全に奪われていく...']
     },
     {
         id: 'restraint-paralysis',
@@ -479,7 +479,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.95,
         weight: 18,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>の神経を痺れさせた', '<TARGET>の体が完全に痺れてしまった...']
+        messages: ['{boss}は{player}の神経を痺れさせた', '{player}の体が完全に痺れてしまった...']
     },
     {
         id: 'restraint-aphrodisiac',
@@ -491,7 +491,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.98,
         weight: 22,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>に直接淫毒を注入した', '<TARGET>の体が激しく火照っていく...']
+        messages: ['{boss}は{player}に直接淫毒を注入した', '{player}の体が激しく火照っていく...']
     },
     {
         id: 'restraint-sleep-induction',
@@ -503,7 +503,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.95,
         weight: 19,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>の意識を朦朧とさせた', '<TARGET>の意識がだんだん遠のいていく...']
+        messages: ['{boss}は{player}の意識を朦朧とさせた', '{player}の意識がだんだん遠のいていく...']
     },
     {
         id: 'restraint-weakness',
@@ -515,7 +515,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.98,
         weight: 21,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>の力を吸い取った', '<TARGET>の体から力が完全に抜けていく...']
+        messages: ['{boss}は{player}の力を吸い取った', '{player}の体から力が完全に抜けていく...']
     },
     {
         id: 'restraint-confusion',
@@ -527,7 +527,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.95,
         weight: 18,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>の思考を混乱させた', '<TARGET>は何が何だかわからなくなっている...']
+        messages: ['{boss}は{player}の思考を混乱させた', '{player}は何が何だかわからなくなっている...']
     },
     {
         id: 'restraint-magic-seal',
@@ -539,7 +539,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.98,
         weight: 17,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>の魔力を封印した', '<TARGET>の魔法が使えなくなった...']
+        messages: ['{boss}は{player}の魔力を封印した', '{player}の魔法が使えなくなった...']
     },
     {
         id: 'restraint-melting',
@@ -551,7 +551,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.95,
         weight: 22,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>の意識をとろけさせた', '<TARGET>の思考が液体のようにとろけていく...']
+        messages: ['{boss}は{player}の意識をとろけさせた', '{player}の思考が液体のようにとろけていく...']
     },
     {
         id: 'restraint-euphoria',
@@ -563,7 +563,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.92,
         weight: 19,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>を恍惚状態にした', '<TARGET>はうっとりと夢見心地になっている...']
+        messages: ['{boss}は{player}を恍惚状態にした', '{player}はうっとりと夢見心地になっている...']
     },
     {
         id: 'restraint-sweet',
@@ -575,7 +575,7 @@ const dreamDemonActions: BossAction[] = [
         statusChance: 0.95,
         weight: 20,
         playerStateCondition: 'restrained',
-        messages: ['<USER>は<TARGET>に甘い幸福感を与えた', '<TARGET>は幸せそうな表情を浮かべている...']
+        messages: ['{boss}は{player}に甘い幸福感を与えた', '{player}は幸せそうな表情を浮かべている...']
     },
     {
         id: 'restraint-hypnosis',
@@ -590,7 +590,7 @@ const dreamDemonActions: BossAction[] = [
         canUse: (_boss, player, _turn) => {
             return player.statusEffects.getDebuffLevel() >= 8;
         },
-        messages: ['<USER>は<TARGET>に強制催眠をかけた', '<TARGET>の意識が完全に支配された...']
+        messages: ['{boss}は{player}に強制催眠をかけた', '{player}の意識が完全に支配された...']
     },
     {
         id: 'restraint-brainwash',
@@ -605,7 +605,7 @@ const dreamDemonActions: BossAction[] = [
         canUse: (_boss, player, _turn) => {
             return player.statusEffects.getDebuffLevel() >= 10;
         },
-        messages: ['<USER>は<TARGET>の思考を洗脳した', '<TARGET>の心が完全に支配されてしまった...']
+        messages: ['{boss}は{player}の思考を洗脳した', '{player}の心が完全に支配されてしまった...']
     },
     
     // Sleep-inducing attacks (restraint-only, after 7 turns restrained)
@@ -625,10 +625,10 @@ const dreamDemonActions: BossAction[] = [
         },
         messages: [
             'ちゅ〜♪ 特別なキスをしてあげるンメェ〜',
-            '<USER>はくちびるに強く魔力を蓄えると、<TARGET>に熱く深いキスをした...',
-            '<TARGET>は眠りに落ちてしまい、<USER>の夢の世界にとらわれてしまった...',
-            '<TARGET>が睡眠状態になった！',
-            '<TARGET>が夢操作状態になった！'
+            '{boss}はくちびるに強く魔力を蓄えると、{player}に熱く深いキスをした...',
+            '{player}は眠りに落ちてしまい、{boss}の夢の世界にとらわれてしまった...',
+            '{player}が睡眠状態になった！',
+            '{player}が夢操作状態になった！'
         ]
     }
 ];
@@ -719,8 +719,8 @@ export const dreamDemonData: BossData = {
                     description: '胃壁で獲物を圧迫して生気を搾り取る',
                     messages: [
                         'おなかの中でぎゅ〜っとしてやるンメェ〜♪',
-                        '<USER>の胃壁が<TARGET>を優しく圧迫してきた...',
-                        '<TARGET>は胃壁に包まれながら生気を吸い取られている...'
+                        '{boss}の胃壁が{player}を優しく圧迫してきた...',
+                        '{player}は胃壁に包まれながら生気を吸い取られている...'
                     ],
                     weight: 1
                 },
@@ -732,8 +732,8 @@ export const dreamDemonData: BossData = {
                     description: '特殊な消化液で獲物を愛撫しながら消化する',
                     messages: [
                         'あまあま〜な消化液でとろとろにしてやるンメェ〜♪',
-                        '<USER>の甘い消化液が<TARGET>を包み込んだ...',
-                        '<TARGET>は消化液に愛撫されながら生気が溶けていく...'
+                        '{boss}の甘い消化液が{player}を包み込んだ...',
+                        '{player}は消化液に愛撫されながら生気が溶けていく...'
                     ],
                     weight: 1
                 },
@@ -745,8 +745,8 @@ export const dreamDemonData: BossData = {
                     description: '胃の内側から優しくマッサージして生気を吸収',
                     messages: [
                         'もみもみ〜♪ 気持ちよくしてあげるンメェ〜',
-                        '<USER>は胃の中で<TARGET>を優しくマッサージしている...',
-                        '<TARGET>は心地よいマッサージを受けながら生気を奪われている...'
+                        '{boss}は胃の中で{player}を優しくマッサージしている...',
+                        '{player}は心地よいマッサージを受けながら生気を奪われている...'
                     ],
                     weight: 1
                 },
@@ -758,8 +758,8 @@ export const dreamDemonData: BossData = {
                     description: '体内で直接生気を吸い取る',
                     messages: [
                         'ちゅーちゅー♪ 生気をいっぱい吸っちゃうンメェ〜',
-                        '<USER>は<TARGET>の生気を直接ちゅーちゅーと吸い取り始めた...',
-                        '<TARGET>は生気を根こそぎ吸い取られて意識が朦朧としている...'
+                        '{boss}は{player}の生気を直接ちゅーちゅーと吸い取り始めた...',
+                        '{player}は生気を根こそぎ吸い取られて意識が朦朧としている...'
                     ],
                     weight: 1
                 }
@@ -778,9 +778,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で永遠に獲物を愛で続ける',
                     messages: [
                         'ずっとずっと一緒にいるンメェ〜♪',
-                        '<USER>は夢の中で<TARGET>を永遠に愛でている...',
-                        '<TARGET>は夢の中で<USER>に愛撫され続けている...',
-                        '<TARGET>の意識は<USER>の夢の中に囚われている...'
+                        '{boss}は夢の中で{player}を永遠に愛でている...',
+                        '{player}は夢の中で{boss}に愛撫され続けている...',
+                        '{player}の意識は{boss}の夢の中に囚われている...'
                     ],
                     statusEffect: StatusEffectType.Charm,
                     weight: 1
@@ -792,9 +792,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で獲物を甘く拘束し続ける',
                     messages: [
                         'もう逃がさないンメェ〜♪ ずっとあたいのものンメェ〜',
-                        '<USER>は夢の中で<TARGET>を甘く拘束している...',
-                        '<TARGET>は夢の拘束から逃れることができない...',
-                        '<TARGET>の心は<USER>の夢に支配されている...'
+                        '{boss}は夢の中で{player}を甘く拘束している...',
+                        '{player}は夢の拘束から逃れることができない...',
+                        '{player}の心は{boss}の夢に支配されている...'
                     ],
                     statusEffect: StatusEffectType.Hypnosis,
                     weight: 1
@@ -806,9 +806,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で獲物に至福を与え続ける',
                     messages: [
                         'あまあま〜な至福をずっと味わわせてあげるンメェ〜♪',
-                        '<USER>は夢の中で<TARGET>に至福を与えている...',
-                        '<TARGET>は夢の中で至福に包まれている...',
-                        '<TARGET>の魂は<USER>の夢に溶けている...'
+                        '{boss}は夢の中で{player}に至福を与えている...',
+                        '{player}は夢の中で至福に包まれている...',
+                        '{player}の魂は{boss}の夢に溶けている...'
                     ],
                     statusEffect: StatusEffectType.Bliss,
                     weight: 1
@@ -820,9 +820,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で獲物を魅了し続ける',
                     messages: [
                         'あたいの魅力にもうメロメロンメェ〜♪',
-                        '<USER>は夢の中で<TARGET>を魅了している...',
-                        '<TARGET>は夢の中で<USER>に魅了され続けている...',
-                        '<TARGET>の心は<USER>の魅力に完全に支配されている...'
+                        '{boss}は夢の中で{player}を魅了している...',
+                        '{player}は夢の中で{boss}に魅了され続けている...',
+                        '{player}の心は{boss}の魅力に完全に支配されている...'
                     ],
                     statusEffect: StatusEffectType.Fascination,
                     weight: 1
@@ -834,9 +834,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で獲物を甘く支配し続ける',
                     messages: [
                         'あたいに完全に支配されちゃったンメェ〜♪',
-                        '<USER>は夢の中で<TARGET>を甘く支配している...',
-                        '<TARGET>は夢の中で<USER>に支配されている...',
-                        '<TARGET>の意志は<USER>の夢に完全に屈服している...'
+                        '{boss}は夢の中で{player}を甘く支配している...',
+                        '{player}は夢の中で{boss}に支配されている...',
+                        '{player}の意志は{boss}の夢に完全に屈服している...'
                     ],
                     statusEffect: StatusEffectType.Brainwash,
                     weight: 1
@@ -856,9 +856,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で体を激しく密着させて生気を吸い取る',
                     messages: [
                         '夢の中でもぺったんぺったんンメェ〜♪',
-                        '<USER>は夢の中で<TARGET>に激しく体を密着させた',
-                        '<USER>は<TARGET>の生気を激しくちゅーちゅーと吸い取っている...',
-                        '<TARGET>は生気が吸い取られているのを感じながら気持ちよくて抵抗できない！'
+                        '{boss}は夢の中で{player}に激しく体を密着させた',
+                        '{boss}は{player}の生気を激しくちゅーちゅーと吸い取っている...',
+                        '{player}は生気が吸い取られているのを感じながら気持ちよくて抵抗できない！'
                     ],
                     weight: 1
                 },
@@ -870,9 +870,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で魔力を込めたべろちゅーで生気を吸い取る',
                     messages: [
                         'べろべろ〜♪ 魔力いっぱいのべろちゅーンメェ〜',
-                        '<USER>は夢の中で魔力を込めて<TARGET>にべろちゅーをした',
-                        '<USER>は<TARGET>の生気をべろちゅーで吸い取っている...',
-                        '<TARGET>は魔力に侵されながら生気を奪われていく...'
+                        '{boss}は夢の中で魔力を込めて{player}にべろちゅーをした',
+                        '{boss}は{player}の生気をべろちゅーで吸い取っている...',
+                        '{player}は魔力に侵されながら生気を奪われていく...'
                     ],
                     weight: 1
                 },
@@ -884,9 +884,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で抱き着いて激しく動きながら生気を吸い取る',
                     messages: [
                         'ぎゅ〜っと抱き着き攻撃ンメェ〜♪',
-                        '<USER>は夢の中で<TARGET>に抱き着いて激しく動いた',
-                        '<USER>は密着しながら<TARGET>の生気をちゅーちゅーと吸い取っている...',
-                        '<TARGET>は抱き着かれながら生気を奪われて快感に溺れている！'
+                        '{boss}は夢の中で{player}に抱き着いて激しく動いた',
+                        '{boss}は密着しながら{player}の生気をちゅーちゅーと吸い取っている...',
+                        '{player}は抱き着かれながら生気を奪われて快感に溺れている！'
                     ],
                     weight: 1
                 },
@@ -898,9 +898,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で触手を使って愛撫しながら生気を吸い取る',
                     messages: [
                         'にゅるにゅる〜♪ 触手いっぱい出しちゃうンメェ〜',
-                        '<USER>は夢の中で無数の触手で<TARGET>を愛撫した',
-                        '<USER>の触手は<TARGET>の生気をじわじわと吸い取っている...',
-                        '<TARGET>は触手に愛撫されながら生気を搾り取られていく...'
+                        '{boss}は夢の中で無数の触手で{player}を愛撫した',
+                        '{boss}の触手は{player}の生気をじわじわと吸い取っている...',
+                        '{player}は触手に愛撫されながら生気を搾り取られていく...'
                     ],
                     weight: 1
                 },
@@ -912,9 +912,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で魔法の力で圧迫しながら生気を吸い取る',
                     messages: [
                         'ぎゅぎゅ〜っと魔法で圧迫しちゃうンメェ〜♪',
-                        '<USER>は夢の中で魔法の力で<TARGET>を圧迫した',
-                        '<USER>は魔法で<TARGET>の生気を強制的に吸い取っている...',
-                        '<TARGET>は魔法に圧迫されながら生気を根こそぎ奪われている！'
+                        '{boss}は夢の中で魔法の力で{player}を圧迫した',
+                        '{boss}は魔法で{player}の生気を強制的に吸い取っている...',
+                        '{player}は魔法に圧迫されながら生気を根こそぎ奪われている！'
                     ],
                     weight: 1
                 },
@@ -926,9 +926,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で激しく揺さぶりながら生気を吸い取る',
                     messages: [
                         'ゆさゆさ〜♪ 激しく揺さぶっちゃうンメェ〜',
-                        '<USER>は夢の中で<TARGET>を激しく揺さぶった',
-                        '<USER>は揺さぶりながら<TARGET>の生気をどんどん吸い取っている...',
-                        '<TARGET>は激しく揺さぶられながら生気を吸い取られて意識が朦朧としている...'
+                        '{boss}は夢の中で{player}を激しく揺さぶった',
+                        '{boss}は揺さぶりながら{player}の生気をどんどん吸い取っている...',
+                        '{player}は激しく揺さぶられながら生気を吸い取られて意識が朦朧としている...'
                     ],
                     weight: 1
                 },
@@ -940,9 +940,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で魅惑的な舞を踊りながら生気を吸い取る',
                     messages: [
                         'くるくる〜♪ 魅惑の舞を踊っちゃうンメェ〜',
-                        '<USER>は夢の中で<TARGET>の周りで魅惑的な舞を踊った',
-                        '<USER>の舞は<TARGET>の生気を踊りながら吸い取っている...',
-                        '<TARGET>は魅惑の舞に見とれながら生気をちゅーちゅー吸われている！'
+                        '{boss}は夢の中で{player}の周りで魅惑的な舞を踊った',
+                        '{boss}の舞は{player}の生気を踊りながら吸い取っている...',
+                        '{player}は魅惑の舞に見とれながら生気をちゅーちゅー吸われている！'
                     ],
                     weight: 1
                 },
@@ -954,9 +954,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で魔力を注入しながら生気を吸い取る',
                     messages: [
                         'ずぶずぶ〜♪ 魔力を直接注入しちゃうンメェ〜',
-                        '<USER>は夢の中で<TARGET>に直接魔力を注入した',
-                        '<USER>の魔力は<TARGET>の生気を内側から吸い取っている...',
-                        '<TARGET>は魔力に侵食されながら生気を内側から奪われていく...'
+                        '{boss}は夢の中で{player}に直接魔力を注入した',
+                        '{boss}の魔力は{player}の生気を内側から吸い取っている...',
+                        '{player}は魔力に侵食されながら生気を内側から奪われていく...'
                     ],
                     weight: 1
                 },
@@ -968,9 +968,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で甘い誘惑をしながら生気を吸い取る',
                     messages: [
                         'あまあま〜♪ 甘い言葉でおびき寄せちゃうンメェ〜',
-                        '<USER>は夢の中で<TARGET>に甘い誘惑をささやいた',
-                        '<USER>は甘い言葉で<TARGET>の生気をそっと吸い取っている...',
-                        '<TARGET>は甘い誘惑に溺れながら生気を静かに奪われている...'
+                        '{boss}は夢の中で{player}に甘い誘惑をささやいた',
+                        '{boss}は甘い言葉で{player}の生気をそっと吸い取っている...',
+                        '{player}は甘い誘惑に溺れながら生気を静かに奪われている...'
                     ],
                     weight: 1
                 },
@@ -982,9 +982,9 @@ export const dreamDemonData: BossData = {
                     description: '夢の中で完全に支配しながら生気を吸い取る',
                     messages: [
                         'もう完全にあたいのものンメェ〜♪ 支配しちゃったンメェ〜',
-                        '<USER>は夢の中で<TARGET>を完全に支配した',
-                        '<USER>は支配した<TARGET>の生気を容赦なく吸い取っている...',
-                        '<TARGET>は完全に支配されながら生気を全て奪われていく！'
+                        '{boss}は夢の中で{player}を完全に支配した',
+                        '{boss}は支配した{player}の生気を容赦なく吸い取っている...',
+                        '{player}は完全に支配されながら生気を全て奪われていく！'
                     ],
                     weight: 1
                 }
@@ -1015,12 +1015,12 @@ export const dreamDemonData: BossData = {
                 name: 'ゆっくり丸呑み',
                 description: '弱り切った獲物をゆっくりと丸呑みにする',
                 messages: [
-                    '<USER>はクスクスと笑い始めた...',
-                    '<TARGET>は生気を吸い取られすぎて動けなくなってしまった...',
-                    '<USER>はゆっくりと<TARGET>に近づいてくる...',
-                    '<USER>は動けなくなった<TARGET>をゆっくりと口に含んでいく......',
+                    '{boss}はクスクスと笑い始めた...',
+                    '{player}は生気を吸い取られすぎて動けなくなってしまった...',
+                    '{boss}はゆっくりと{player}に近づいてくる...',
+                    '{boss}は動けなくなった{player}をゆっくりと口に含んでいく......',
                     'ごっくん......',
-                    '<TARGET>は<USER>のお腹の中に取り込まれてしまった...'
+                    '{player}は{boss}のお腹の中に取り込まれてしまった...'
                 ],
                 weight: 1
             };
@@ -1036,9 +1036,9 @@ export const dreamDemonData: BossData = {
                         name: 'ゆっくり丸呑み',
                         description: '拘束した獲物をゆっくりと丸呑みにする',
                         messages: [
-                            '<USER>はクスクスと笑い始めた...',
-                            '<USER>はゆっくりと<TARGET>に近づいてくる...',
-                            '<USER>は<TARGET>をゆっくりと口に含んでいく......',
+                            '{boss}はクスクスと笑い始めた...',
+                            '{boss}はゆっくりと{player}に近づいてくる...',
+                            '{boss}は{player}をゆっくりと口に含んでいく......',
                             'ごっくん......'
                         ],
                         weight: 1
@@ -1059,8 +1059,8 @@ export const dreamDemonData: BossData = {
                         name: 'ゆっくり丸呑み',
                         description: '無防備な獲物をゆっくりと丸呑みにする',
                         messages: [
-                            '<USER>はクスクスと笑い始めた...',
-                            '<USER>は<TARGET>をゆっくりと口に含んでいく......',
+                            '{boss}はクスクスと笑い始めた...',
+                            '{boss}は{player}をゆっくりと口に含んでいく......',
                             'ごっくん......'
                         ],
                         weight: 1
@@ -1255,9 +1255,9 @@ dreamDemonData.getDialogue = function(situation: 'battle-start' | 'player-restra
 // Add finishing move for final victory
 dreamDemonData.finishingMove = function() {
     return [
-        '<USER>は力尽きた<TARGET>を完全に消化してしまった...',
-        '<USER>はお腹をさすりながら満足げな表情を浮かべる',
+        '{boss}は力尽きた{player}を完全に消化してしまった...',
+        '{boss}はお腹をさすりながら満足げな表情を浮かべる',
         'けぷっ、おいしかったンメェ〜',
-        '<TARGET>は<USER>の一部となって永遠に夢の世界に残ることになった...'
+        '{player}は{boss}の一部となって永遠に夢の世界に残ることになった...'
     ];
 };

--- a/src/game/data/bosses/dual-jester.ts
+++ b/src/game/data/bosses/dual-jester.ts
@@ -11,7 +11,7 @@ const dualJesterPhase1Actions: BossAction[] = [
         description: '可愛く手をぽんぽんと叩く',
         messages: [
             '「一緒に遊ぼうよ〜♪」',
-            '<USER>は<TARGET>を可愛く軽くぽんぽんと叩く！',
+            '{boss}は{player}を可愛く軽くぽんぽんと叩く！',
             'とても軽いタッチで、まるで遊んでいるようだ'
         ],
         damageFormula: (user: Boss) => Math.max(1, user.attackPower * 0.15), // 非常に軽いダメージ
@@ -26,8 +26,8 @@ const dualJesterPhase1Actions: BossAction[] = [
         description: '遊びのつもりで軽く拘束する',
         messages: [
             '「はーい、おいかけっこの時間だよ〜♪」',
-            '<USER>は<TARGET>を遊びのつもりで軽く捕まえる！',
-            '<TARGET>は拘束されたが、なんとなく脱出しやすそうだ...'
+            '{boss}は{player}を遊びのつもりで軽く捕まえる！',
+            '{player}は拘束されたが、なんとなく脱出しやすそうだ...'
         ],
         statusEffect: StatusEffectType.FalseSecurity,
         statusChance: 0.60,
@@ -43,8 +43,8 @@ const dualJesterPhase1Actions: BossAction[] = [
         description: 'くすぐって笑わせようとする',
         messages: [
             '「くすぐっちゃうぞ〜♪」',
-            '<USER>は<TARGET>をくすぐって笑わせようとする！',
-            '<TARGET>は笑いそうになった...'
+            '{boss}は{player}をくすぐって笑わせようとする！',
+            '{player}は笑いそうになった...'
         ],
         damageFormula: (user: Boss) => Math.max(1, user.attackPower * 0.20),
         statusEffect: StatusEffectType.Charm,
@@ -59,7 +59,7 @@ const dualJesterPhase1Actions: BossAction[] = [
         description: '食べる真似をするが実際は食べない',
         messages: [
             '「食べちゃうぞ〜♪ でも冗談だよ〜」',
-            '<USER>は<TARGET>を口に入れるような素振りを見せる！',
+            '{boss}は{player}を口に入れるような素振りを見せる！',
             'でも実際は演技のようで、本気ではないようだ...'
         ],
         hitRate: 0.0,
@@ -75,7 +75,7 @@ const dualJesterPhase1Actions: BossAction[] = [
         description: '手を繋ぐ振りで軽い電撃攻撃',
         messages: [
             '「お手々つなごうよ〜♪」',
-            '<USER>は<TARGET>の手を取って可愛く手を繋ごうとする！',
+            '{boss}は{player}の手を取って可愛く手を繋ごうとする！',
             'しかし手から軽い電撃がビリッと流れた！',
             '「あれ？静電気かな〜？ えへへ♪」'
         ],
@@ -93,8 +93,8 @@ const dualJesterPhase1Actions: BossAction[] = [
         description: 'くるくる回って相手を混乱させる',
         messages: [
             '「くるくる〜♪ 一緒に回ろうよ〜♪」',
-            '<USER>が高速でくるくる回転しながら<TARGET>の周りを飛び回る！',
-            '目が回るような動きに<TARGET>は混乱してしまった...',
+            '{boss}が高速でくるくる回転しながら{player}の周りを飛び回る！',
+            '目が回るような動きに{player}は混乱してしまった...',
             '「どっちが前でどっちが後ろかな〜♪」'
         ],
         damageFormula: (user: Boss) => Math.max(1, user.attackPower * 0.20),
@@ -111,9 +111,9 @@ const dualJesterPhase1Actions: BossAction[] = [
         description: '瞬間移動して不意打ち攻撃',
         messages: [
             '「かくれんぼしよう〜♪」',
-            '<USER>がぱっと姿を消した！',
+            '{boss}がぱっと姿を消した！',
             '「もーいいかい？」',
-            '後ろから現れた<USER>が<TARGET>を軽くぽんと叩く！'
+            '後ろから現れた{boss}が{player}を軽くぽんと叩く！'
         ],
         damageFormula: (user: Boss) => Math.max(3, user.attackPower * 0.30),
         hitRate: 0.85,
@@ -131,8 +131,8 @@ const dualJesterPhase2Actions: BossAction[] = [
         description: '不気味な瞳で威嚇攻撃',
         messages: [
             '「...フフフ、怖がってるね」',
-            '<USER>の瞳が異様な光を放ち、<TARGET>を見据える！',
-            '<TARGET>は恐怖で体が震えてしまった...',
+            '{boss}の瞳が異様な光を放ち、{player}を見据える！',
+            '{player}は恐怖で体が震えてしまった...',
             '「その表情...とても美しいよ」'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.2,
@@ -149,8 +149,8 @@ const dualJesterPhase2Actions: BossAction[] = [
         description: '心理攻撃で恐怖を植え付ける',
         messages: [
             '「聞こえるかい？君の心の奥の悲鳴が...」',
-            '<USER>が<TARGET>の耳元で何か囁いている...',
-            '<TARGET>は得体の知れない恐怖に包まれた！',
+            '{boss}が{player}の耳元で何か囁いている...',
+            '{player}は得体の知れない恐怖に包まれた！',
             '「これはまだ始まりに過ぎない...」'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.8,
@@ -170,8 +170,8 @@ const dualJesterPhase2Actions: BossAction[] = [
             '「死ね」',
             '「楽しいね〜♪」',
             '「苦しめ」',
-            '<USER>が表情を高速で切り替えながら突進してくる！',
-            '<TARGET>は人格の急変に混乱しながら攻撃を受けた！',
+            '{boss}が表情を高速で切り替えながら突進してくる！',
+            '{player}は人格の急変に混乱しながら攻撃を受けた！',
             '「どっちが本当？...両方とも本当さ」'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
@@ -188,8 +188,8 @@ const dualJesterPhase2Actions: BossAction[] = [
         description: '周囲の玩具を操って攻撃',
         messages: [
             '「僕の大切な玩具たちよ...遊んでおやり」',
-            '<USER>が手を振ると周囲の壊れた玩具が一斉に浮き上がる！',
-            '玩具たちが<TARGET>に向かって飛んできた！',
+            '{boss}が手を振ると周囲の壊れた玩具が一斉に浮き上がる！',
+            '玩具たちが{player}に向かって飛んできた！',
             '「みんな君と遊びたがってるよ...永遠にね」'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.4,
@@ -204,8 +204,8 @@ const dualJesterPhase2Actions: BossAction[] = [
         description: '本気の拘束技を繰り出す',
         messages: [
             '「...さっきは手加減していただけだ」',
-            '<USER>の顔が反転し、色調が暗く変化する！',
-            '<TARGET>が強力な拘束に捕らわれた！'
+            '{boss}の顔が反転し、色調が暗く変化する！',
+            '{player}が強力な拘束に捕らわれた！'
         ],
         statusEffect: StatusEffectType.Manic,
         statusChance: 0.70,
@@ -221,7 +221,7 @@ const dualJesterPhase2Actions: BossAction[] = [
         description: '狂気の笑いと共に強く締め付ける',
         messages: [
             '「もっと...もっと一緒にいよう...♪」',
-            '<USER>は<TARGET>を狂気的な力で締め付ける！'
+            '{boss}は{player}を狂気的な力で締め付ける！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.8,
         statusEffect: StatusEffectType.Bipolar,
@@ -237,7 +237,7 @@ const dualJesterPhase2Actions: BossAction[] = [
         messages: [
             '「大丈夫、痛くないよ〜」',
             '「痛がってる顔、とても美しいね」',
-            '<USER>人格が変化しながら、リボンのような長い舌が<TARGET>を舐め回す！'
+            '{boss}人格が変化しながら、リボンのような長い舌が{player}を舐め回す！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         statusEffect: StatusEffectType.Confusion,
@@ -252,8 +252,8 @@ const dualJesterPhase2Actions: BossAction[] = [
         description: '今度は本当に食べてしまう',
         messages: [
             '「今度は本当に食べてあげる...永遠に一緒にいられるよ」',
-            '<USER>のリボンのような長い舌が<TARGET>を巻き上げ、そのまま飲み込んでいく！',
-            'まるでエアドームのような胃袋が<USER>を包み込む...'
+            '{boss}のリボンのような長い舌が{player}を巻き上げ、そのまま飲み込んでいく！',
+            'まるでエアドームのような胃袋が{boss}を包み込む...'
         ],
         weight: 25,
         canUse: (_boss, player, _turn) => {
@@ -272,7 +272,7 @@ const dualJesterDevourActions: BossAction[] = [
         messages: [
             '「ママのお腹の中みたいにぎゅ～ってしてあげる♪」',
             '「我が抱擁に包まれて、安心して眠るがいい...」',
-            '体内の空間が急激に縮まり、胃壁が<TARGET>を圧迫する！',
+            '体内の空間が急激に縮まり、胃壁が{player}を圧迫する！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 2.0,
         weight: 35,
@@ -286,7 +286,7 @@ const dualJesterDevourActions: BossAction[] = [
         messages: [
             '「水遊びしようよ〜♪お腹の中であったか〜い♪」',
             '「そのまま我がプールで溺れてしまうがよい...」',
-            'ピンクと紫の胃液が<TARGET>を包みこみ、生命力を溶かしていく！',
+            'ピンクと紫の胃液が{player}を包みこみ、生命力を溶かしていく！',
         ],
         statusEffect: StatusEffectType.Slimed,
         statusChance: 1.0,
@@ -302,7 +302,7 @@ const dualJesterDevourActions: BossAction[] = [
         messages: [
             '「楽しい夢を見せてあげる♪ママのお腹の中みたいに安心でしょ〜？」',
             '「...それとも永遠の悪夢がお好み？フフフ...」',
-            '<USER>の胃袋が<TARGET>をやさしくゆさぶり、甘美な安らぎと恐ろしい悪夢を同時に体験させる！'
+            '{boss}の胃袋が{player}をやさしくゆさぶり、甘美な安らぎと恐ろしい悪夢を同時に体験させる！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.8,
         statusEffect: StatusEffectType.FalseSecurity,
@@ -322,9 +322,9 @@ const dualJesterEternalActions: BossAction[] = [
         description: '裏の人格がおもちゃ箱に出現し、永遠に遊び続ける相手になる',
         messages: [
             '「君一人では淋しいだろう？私が遊び相手になろう」',
-            'おもちゃ箱の中に裏の人格の分身が、ぬいぐるみになった<TARGET>よりはるかに大きい姿で現れる！',
+            'おもちゃ箱の中に裏の人格の分身が、ぬいぐるみになった{player}よりはるかに大きい姿で現れる！',
             '「さあ、何をして遊ぼうか？」',
-            'ぬいぐるみにされてしまった<TARGET>は、動くことも答えることもできない...'
+            'ぬいぐるみにされてしまった{player}は、動くことも答えることもできない...'
         ],
         weight: 35,
         playerStateCondition: 'defeated',
@@ -338,11 +338,11 @@ const dualJesterEternalActions: BossAction[] = [
         name: '強制抱擁',
         description: '巨大な体でぬいぐるみを強くきつく抱きしめる',
         messages: [
-            '裏の人格の巨大な両腕が<TARGET>をぎゅっと抱きしめる！',
+            '裏の人格の巨大な両腕が{player}をぎゅっと抱きしめる！',
             '「やっと手に入れた大切な玩具だ...絶対に離さない」',
-            '巨大な体格で容赦なく抱きしめられ、<TARGET>は身動きが全く取れない！',
+            '巨大な体格で容赦なく抱きしめられ、{player}は身動きが全く取れない！',
             '「この感触...やはり本物の玩具は格別だな」',
-            '強すぎる抱擁で<TARGET>の体はスポンジのように押しつぶされる...'
+            '強すぎる抱擁で{player}の体はスポンジのように押しつぶされる...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         statusEffect: StatusEffectType.Paralysis,
@@ -358,7 +358,7 @@ const dualJesterEternalActions: BossAction[] = [
         messages: [
             '巨大な体の口からリボンのような長い舌がにゅるりと現れる！',
             '「味見をさせてもらおうか...」',
-            '濡れた舌が<TARGET>の全身を執拗に舐め回す！',
+            '濡れた舌が{player}の全身を執拗に舐め回す！',
             '「君の味は...実に素晴らしい。もっと、もっと味わわせてもらう」',
             'ぬいぐるみにされた体でも、妙な感覚が残り続ける...',
             '「嫌がる表情すら見せられないとは...完璧な玩具だ」'
@@ -375,12 +375,12 @@ const dualJesterEternalActions: BossAction[] = [
         name: '無慈悲くすぐり',
         description: '巨大な指でぬいぐるみをくすぐりまわす',
         messages: [
-            '裏の人格の巨大な指が<TARGET>に向かって迫る！',
+            '裏の人格の巨大な指が{player}に向かって迫る！',
             '「くすぐりは痛みよりも効果的だ...抵抗すらできないからな」',
-            '大きな指が<TARGET>の体を執拗にくすぐり続ける！',
+            '大きな指が{player}の体を執拗にくすぐり続ける！',
             'ぬいぐるみにされても、くすぐられる感覚だけは鮮明に残る...',
             '「笑い声も出せない...実に素晴らしい反応だ」',
-            '容赦なく続くくすぐりに、<TARGET>の意識は混乱する...'
+            '容赦なく続くくすぐりに、{player}の意識は混乱する...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.2,
         statusEffect: StatusEffectType.Confusion,
@@ -394,11 +394,11 @@ const dualJesterEternalActions: BossAction[] = [
         name: '玩具振り回し',
         description: '巨大な手でぬいぐるみを激しく振り回す',
         messages: [
-            '裏の人格が<TARGET>を巨大な手で掴み上げる！',
+            '裏の人格が{player}を巨大な手で掴み上げる！',
             '「玩具は乱暴に扱っても壊れないものでなくては...」',
-            '<TARGET>が激しく空中で振り回される！',
+            '{player}が激しく空中で振り回される！',
             '「どれほどの衝撃に耐えられるか試してみよう」',
-            '激しい振り回しで<TARGET>の視界がぐるぐると回る...',
+            '激しい振り回しで{player}の視界がぐるぐると回る...',
             '「この程度では壊れないか...流石は丈夫な玩具だ」'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.4,
@@ -413,11 +413,11 @@ const dualJesterEternalActions: BossAction[] = [
         name: '支配的遊戯',
         description: '巨大な体格を活かして絶対的な支配を誇示する',
         messages: [
-            '裏の人格が<TARGET>の真上に巨大な体を覆いかぶせる！',
+            '裏の人格が{player}の真上に巨大な体を覆いかぶせる！',
             '「私の大きさが分かるか？君はこんなにも小さな存在なのだ」',
-            '圧倒的な体格差で<TARGET>を完全に覆い隠す！',
+            '圧倒的な体格差で{player}を完全に覆い隠す！',
             '「抵抗など不可能...君は私の手の平の上の玩具に過ぎない」',
-            '巨大な影に包まれ、<TARGET>は自分の無力さを思い知らされる...',
+            '巨大な影に包まれ、{player}は自分の無力さを思い知らされる...',
             '「この支配関係は永遠に変わることはない」'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.6,
@@ -432,9 +432,9 @@ const dualJesterEternalActions: BossAction[] = [
         name: '執拗愛撫',
         description: '巨大な手で執拗で一方的な愛撫を行う',
         messages: [
-            '裏の人格の巨大な手が<TARGET>に触れ始める...',
+            '裏の人格の巨大な手が{player}に触れ始める...',
             '「この感触...何度味わっても飽きることがない」',
-            '大きな手が<TARGET>の体を執拗に、丁寧に撫で回す！',
+            '大きな手が{player}の体を執拗に、丁寧に撫で回す！',
             '「君のこの部分は特に...興味深いな」',
             'ぬいぐるみにされた体でも、奇妙な感覚が伝わり続ける...',
             '「私だけが君を完全に理解している...私だけが君を愛している」',
@@ -469,7 +469,7 @@ const dualJesterAIStrategy = (boss: Boss, player: Player, turn: number): BossAct
                 '「...あれ？まだ遊びたいの？」',
                 '可愛らしい道化師の仮面が剥がれ落ち、真の恐怖が姿を現す！',
                 '「なら...本気で遊ぼうか」',
-                '狂気に染まった目が<TARGET>を見据え、表情が一変する！',
+                '狂気に染まった目が{player}を見据え、表情が一変する！',
             ],
             weight: 1,
             playerStateCondition: 'normal'
@@ -678,13 +678,13 @@ export const dualJesterData: BossData = {
 // フィニッシュムーブの実装
 dualJesterData.finishingMove = function(): string[] {
     return [
-        '胃液に包まれ、生命力を奪われた<TARGET>はぬいぐるみの姿に変えられてしまった！',
+        '胃液に包まれ、生命力を奪われた{player}はぬいぐるみの姿に変えられてしまった！',
         '「だいすき〜♪ ずっと一緒にいようね〜♪」',
         '「...ついに完璧な玩具を手に入れた」',
-        '<TARGET>は体内の奥に運ばれ、まるでおもちゃ箱のような空間に閉じ込められる...',
-        '「そこが<USER>の新しいお家だよ～♪」',
+        '{player}は体内の奥に運ばれ、まるでおもちゃ箱のような空間に閉じ込められる...',
+        '「そこが{boss}の新しいお家だよ～♪」',
         '「私が遊び相手になってあげよう...飽きるまでずっと一緒だ」',
-        '体内のおもちゃ箱に閉じ込められた<USER>は、双面の道化師の玩具として遊ばれ続けることになった...'
+        '体内のおもちゃ箱に閉じ込められた{boss}は、双面の道化師の玩具として遊ばれ続けることになった...'
     ];
 };
 

--- a/src/game/data/bosses/fluffy-dragon.ts
+++ b/src/game/data/bosses/fluffy-dragon.ts
@@ -14,7 +14,7 @@ const fluffyDragonActions: BossAction[] = [
         playerStateCondition: 'normal',
         messages: [
             'ふわふわ〜♪ やさしくしてあげるね',
-            '<USER>はふわふわの毛で<TARGET>を優しく包み込むように攻撃した'
+            '{boss}はふわふわの毛で{player}を優しく包み込むように攻撃した'
         ]
     },
     {
@@ -28,7 +28,7 @@ const fluffyDragonActions: BossAction[] = [
         playerStateCondition: 'normal',
         messages: [
             'ぽふぽふ〜♪ 毛玉攻撃だよ',
-            '<USER>はふわふわの毛玉を<TARGET>に向けて飛ばした！'
+            '{boss}はふわふわの毛玉を{player}に向けて飛ばした！'
         ]
     },
 
@@ -45,8 +45,8 @@ const fluffyDragonActions: BossAction[] = [
         weight: 30,
         messages: [
             'ふわ〜♪ いい香りのブレスをどうぞ',
-            '<USER>はラベンダーの香りがする甘いブレスを吐いた',
-            '<TARGET>は心地よい香りに包まれている...'
+            '{boss}はラベンダーの香りがする甘いブレスを吐いた',
+            '{player}は心地よい香りに包まれている...'
         ],
         canUse: (_boss, _player, _turn) => {
             // Always available
@@ -61,7 +61,7 @@ const fluffyDragonActions: BossAction[] = [
                 // 眠気状態を削除して睡眠状態を付与
                 player.statusEffects.removeEffect(StatusEffectType.Sleepy);
                 player.statusEffects.addEffect(StatusEffectType.Sleep, 3);
-                messages.push('<TARGET>は深い眠りに落ちてしまった...');
+                messages.push('{player}は深い眠りに落ちてしまった...');
             }
             return messages;
         }
@@ -78,8 +78,8 @@ const fluffyDragonActions: BossAction[] = [
         weight: 25,
         messages: [
             'ふわふわ〜♪ 心地よいオーラだよ',
-            '<USER>のふわふわの毛から心地よいオーラが漂ってきた',
-            '<TARGET>は心地よさで力が抜けていく...'
+            '{boss}のふわふわの毛から心地よいオーラが漂ってきた',
+            '{player}は心地よさで力が抜けていく...'
         ]
     },
 
@@ -93,8 +93,8 @@ const fluffyDragonActions: BossAction[] = [
         hitRate: 0.85,
         messages: [
             'ふわふわ〜♪ ぎゅーってしてあげる',
-            '<USER>はふわふわの毛で<TARGET>を優しく包み込もうとしてきた！',
-            '<TARGET>はふわふわの毛に包まれて身動きが取れなくなった...'
+            '{boss}はふわふわの毛で{player}を優しく包み込もうとしてきた！',
+            '{player}はふわふわの毛に包まれて身動きが取れなくなった...'
         ],
         canUse: (_boss, player, _turn) => {
             // 眠気状態や睡眠状態の時により使いやすく
@@ -116,9 +116,9 @@ const fluffyDragonActions: BossAction[] = [
         weight: 1,
         messages: [
             'ふわふわ〜♪ お腹の中で暖かくしてあげる',
-            '<USER>は<TARGET>を優しく口に含んで...',
+            '{boss}は{player}を優しく口に含んで...',
             'ごくん...',
-            '<TARGET>は<USER>のふわふわな胃袋に包まれた...'
+            '{player}は{boss}のふわふわな胃袋に包まれた...'
         ]
     },
 
@@ -133,8 +133,8 @@ const fluffyDragonActions: BossAction[] = [
         playerStateCondition: 'restrained',
         messages: [
             'ふわふわ〜♪ 気持ちよくしてあげる',
-            '<USER>はふわふわの毛で<TARGET>を優しくマッサージした',
-            '<TARGET>は心地よいマッサージに身を委ねている...'
+            '{boss}はふわふわの毛で{player}を優しくマッサージした',
+            '{player}は心地よいマッサージに身を委ねている...'
         ]
     },
     {
@@ -149,8 +149,8 @@ const fluffyDragonActions: BossAction[] = [
         playerStateCondition: 'restrained',
         messages: [
             'ふわふわ〜♪ 暖かくて眠くなるでしょ？',
-            '<USER>は<TARGET>を暖かく包み込んだ',
-            '<TARGET>は暖かさで眠気に襲われている...'
+            '{boss}は{player}を暖かく包み込んだ',
+            '{player}は暖かさで眠気に襲われている...'
         ]
     }
 ];
@@ -165,8 +165,8 @@ const fluffyStomachActions: BossAction[] = [
         description: 'ふわふわな胃袋の毛による優しい圧迫攻撃',
         messages: [
             'ふわふわ〜♪ お腹の中でも気持ちよくしてあげる',
-            '<USER>のふわふわな胃袋が<TARGET>を優しくマッサージしている...',
-            '<TARGET>は胃袋の毛に包まれながら生気を吸い取られている...'
+            '{boss}のふわふわな胃袋が{player}を優しくマッサージしている...',
+            '{player}は胃袋の毛に包まれながら生気を吸い取られている...'
         ],
         weight: 1
     },
@@ -178,8 +178,8 @@ const fluffyStomachActions: BossAction[] = [
         description: '眠りを誘う特殊な空気を送り込む',
         messages: [
             'ふわふわ〜♪ もっと眠くなる空気をどうぞ',
-            '<USER>は胃袋の中に眠りを誘う甘い空気を送り込んだ...',
-            '<TARGET>は甘い空気に包まれながら最大HPを奪われていく...'
+            '{boss}は胃袋の中に眠りを誘う甘い空気を送り込んだ...',
+            '{player}は甘い空気に包まれながら最大HPを奪われていく...'
         ],
         weight: 1
     },
@@ -191,8 +191,8 @@ const fluffyStomachActions: BossAction[] = [
         description: '体温による心地よい包み込み攻撃',
         messages: [
             'ふわふわ〜♪ ずっと暖かくしてあげる',
-            '<USER>の胃袋が<TARGET>を温かく包み込んでいる...',
-            '<TARGET>は心地よい温かさの中で力を失っていく...'
+            '{boss}の胃袋が{player}を温かく包み込んでいる...',
+            '{player}は心地よい温かさの中で力を失っていく...'
         ],
         weight: 1
     }
@@ -207,9 +207,9 @@ const deepStomachActions: BossAction[] = [
         description: '粘液に包まれながら丸呑みされる夢を見続ける',
         messages: [
             'ふわふわ〜♪ いい夢を見せてあげる',
-            '<USER>の奥の胃袋で<TARGET>は粘液に包まれている...',
-            '<TARGET>は丸呑みされる夢を何度も見続けている...',
-            '<TARGET>の意識は<USER>の夢の世界に囚われている...'
+            '{boss}の奥の胃袋で{player}は粘液に包まれている...',
+            '{player}は丸呑みされる夢を何度も見続けている...',
+            '{player}の意識は{boss}の夢の世界に囚われている...'
         ],
         statusEffect: StatusEffectType.Sleep,
         weight: 1
@@ -221,9 +221,9 @@ const deepStomachActions: BossAction[] = [
         description: '目覚めを阻止する強制睡眠',
         messages: [
             'ふわふわ〜♪ ずっと眠っていてね',
-            '<USER>は<TARGET>を深い眠りに閉じ込めている...',
-            '<TARGET>は目覚めることができない...',
-            '<TARGET>の魂は<USER>の中で永遠に眠り続ける...'
+            '{boss}は{player}を深い眠りに閉じ込めている...',
+            '{player}は目覚めることができない...',
+            '{player}の魂は{boss}の中で永遠に眠り続ける...'
         ],
         statusEffect: StatusEffectType.Hypnosis,
         weight: 1
@@ -235,9 +235,9 @@ const deepStomachActions: BossAction[] = [
         description: 'ねっとりした粘液による包み込み',
         messages: [
             'ふわふわ〜♪ ねっとり包んであげる',
-            '<USER>の粘液が<TARGET>をねっとりと包み込んでいる...',
-            '<TARGET>は粘液に愛撫されながら意識を失っていく...',
-            '<TARGET>の心は<USER>の胃袋に完全に支配されている...'
+            '{boss}の粘液が{player}をねっとりと包み込んでいる...',
+            '{player}は粘液に愛撫されながら意識を失っていく...',
+            '{player}の心は{boss}の胃袋に完全に支配されている...'
         ],
         statusEffect: StatusEffectType.Melting,
         weight: 1
@@ -249,9 +249,9 @@ const deepStomachActions: BossAction[] = [
         description: '完全な支配状態での至福演出',
         messages: [
             'ふわふわ〜♪ もう何も心配いらないよ',
-            '<USER>は<TARGET>を永遠の安らぎで包んでいる...',
-            '<TARGET>は完全に安らかな表情を浮かべている...',
-            '<TARGET>は<USER>の一部として永遠に過ごすことになった...'
+            '{boss}は{player}を永遠の安らぎで包んでいる...',
+            '{player}は完全に安らかな表情を浮かべている...',
+            '{player}は{boss}の一部として永遠に過ごすことになった...'
         ],
         statusEffect: StatusEffectType.Bliss,
         weight: 1
@@ -307,9 +307,9 @@ export const fluffyDragonData: BossData = {
                 description: 'ふわふわ胃袋から本物の胃袋へ移動させる',
                 messages: [
                     'ふわふわ〜♪ より奥で休んでもらいましょう',
-                    '<TARGET>は完全に眠りに落ち、<USER>のより奥の胃袋に送られていく...',
+                    '{player}は完全に眠りに落ち、{boss}のより奥の胃袋に送られていく...',
                     'そこはねっとりした粘液に満ちた本物の胃袋だった...',
-                    '<USER>が起きている限り、<TARGET>は目覚めることができない...'
+                    '{boss}が起きている限り、{player}は目覚めることができない...'
                 ],
                 weight: 1
             };
@@ -397,10 +397,10 @@ export const fluffyDragonData: BossData = {
     // カスタムフィニッシュムーブ
     finishingMove: function() {
         return [
-            '<USER>は力尽きた<TARGET>を奥の胃袋で完全に消化してしまった...',
-            '<USER>はお腹をさすりながら満足げな表情を浮かべる',
+            '{boss}は力尽きた{player}を奥の胃袋で完全に消化してしまった...',
+            '{boss}はお腹をさすりながら満足げな表情を浮かべる',
             'ふわふわ〜♪ とても美味しかったです',
-            '<TARGET>は<USER>の一部となって永遠にふわふわの夢の中で過ごすことになった...'
+            '{player}は{boss}の一部となって永遠にふわふわの夢の中で過ごすことになった...'
         ];
     },
     

--- a/src/game/data/bosses/mech-spider.ts
+++ b/src/game/data/bosses/mech-spider.ts
@@ -8,7 +8,7 @@ const mechSpiderActions: BossAction[] = [
         type: ActionType.Attack,
         name: 'レーザーショット',
         description: '精密なレーザーで攻撃する',
-        messages: ['<USER>は精密なレーザーで<TARGET>を狙撃する！'],
+        messages: ['{boss}は精密なレーザーで{player}を狙撃する！'],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         hitRate: 0.9,
         weight: 20
@@ -18,7 +18,7 @@ const mechSpiderActions: BossAction[] = [
         type: ActionType.Attack,
         name: 'クモキック',
         description: '強力だが不正確な蹴り攻撃',
-        messages: ['<USER>は機械の脚で<TARGET>を蹴り飛ばそうとする！'],
+        messages: ['{boss}は機械の脚で{player}を蹴り飛ばそうとする！'],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         hitRate: 0.6,
         weight: 15,
@@ -30,7 +30,7 @@ const mechSpiderActions: BossAction[] = [
         type: ActionType.StatusAttack,
         name: 'ショックバイト',
         description: '噛みついて電気ショックを与える',
-        messages: ['<USER>は<TARGET>に噛みついて電気ショックを流す！'],
+        messages: ['{boss}は{player}に噛みついて電気ショックを流す！'],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         statusEffect: StatusEffectType.Stunned,
         statusChance: 0.30,
@@ -45,7 +45,7 @@ const mechSpiderActions: BossAction[] = [
         type: ActionType.RestraintAttack,
         name: 'スパイダーグラブ',
         description: '抱きしめるように拘束する',
-        messages: ['<USER>は機械の腕で<TARGET>を抱きしめて拘束しようとする！'],
+        messages: ['{boss}は機械の腕で{player}を抱きしめて拘束しようとする！'],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         weight: 25,
         canUse: (_boss, player, _turn) => {
@@ -57,7 +57,7 @@ const mechSpiderActions: BossAction[] = [
         type: ActionType.RestraintAttack,
         name: 'スパイダーネット',
         description: '機械の合成糸で作った網で拘束する',
-        messages: ['<USER>は合成糸の網を<TARGET>に投げかける！'],
+        messages: ['{boss}は合成糸の網を{player}に投げかける！'],
         damage: 0,
         weight: 30,
         canUse: (_boss, player, _turn) => {
@@ -73,7 +73,7 @@ const mechSpiderActionsRestrained: BossAction[] = [
         type: ActionType.Attack,
         name: 'クモキック',
         description: '強力だが不正確な蹴り攻撃',
-        messages: ['<USER>は機械の脚で<TARGET>を蹴りつける！'],
+        messages: ['{boss}は機械の脚で{player}を蹴りつける！'],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         weight: 20
     },
@@ -83,7 +83,7 @@ const mechSpiderActionsRestrained: BossAction[] = [
         type: ActionType.StatusAttack,
         name: 'ショックバイト',
         description: '噛みついて電気ショックを与える',
-        messages: ['<USER>は<TARGET>に噛みついて電気ショックを流す！'],
+        messages: ['{boss}は{player}に噛みついて電気ショックを流す！'],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         statusEffect: StatusEffectType.Stunned,
         statusChance: 0.50,
@@ -95,7 +95,7 @@ const mechSpiderActionsRestrained: BossAction[] = [
         type: ActionType.Attack,
         name: 'スパイダーハグ',
         description: '抱きしめるように締め付ける',
-        messages: ['<USER>は機械の腕で<TARGET>を締め付ける！'],
+        messages: ['{boss}は機械の腕で{player}を締め付ける！'],
         damageFormula: (user: Boss) => user.attackPower * 1.8,
         weight: 25
     }
@@ -109,8 +109,8 @@ const mechSpiderActionsKnockoutRestrained: BossAction[] = [
         name: '縮小プロセス',
         description: '捕まえた対象を繭にして縮小液で満たす',
         messages: [
-            '<USER>は<TARGET>を合成糸でぐるぐる巻きにし始める！',
-            '<TARGET>が繭の中に閉じ込められ、内部が縮小液で満たされる！'
+            '{boss}は{player}を合成糸でぐるぐる巻きにし始める！',
+            '{player}が繭の中に閉じ込められ、内部が縮小液で満たされる！'
         ],
         weight: 1,
         canUse: (_boss, player, _turn) => {
@@ -127,7 +127,7 @@ const mechSpiderActionsCocoon: BossAction[] = [
         type: ActionType.CocoonAction,
         name: '繭の抱擁',
         description: '繭状態の対象をゆらゆら揺らして縮小させる',
-        messages: ['<USER>は繭を優しく抱擁し、ゆらゆらと揺らしている...'],
+        messages: ['{boss}は繭を優しく抱擁し、ゆらゆらと揺らしている...'],
         damageFormula: (user: Boss) => user.attackPower * 1.0, // Max HP reduction amount
         weight: 30,
         playerStateCondition: 'cocoon',
@@ -140,7 +140,7 @@ const mechSpiderActionsCocoon: BossAction[] = [
         type: ActionType.CocoonAction,
         name: '繭の圧縮',
         description: '繭を抱きしめて縮小液を馴染ませる',
-        messages: ['<USER>は繭を強く抱きしめ、縮小液を<TARGET>に馴染ませる！'],
+        messages: ['{boss}は繭を強く抱きしめ、縮小液を{player}に馴染ませる！'],
         damageFormula: (user: Boss) => user.attackPower * 1.8, // Max HP reduction amount
         weight: 25,
         playerStateCondition: 'cocoon',
@@ -153,7 +153,7 @@ const mechSpiderActionsCocoon: BossAction[] = [
         type: ActionType.CocoonAction,
         name: '縮小液循環',
         description: '繭内部の縮小液を循環させてエネルギーを得る',
-        messages: ['<USER>は繭内部の縮小液を循環させ、<TARGET>のエネルギーを吸収する！'],
+        messages: ['{boss}は繭内部の縮小液を循環させ、{player}のエネルギーを吸収する！'],
         damageFormula: (user: Boss) => user.attackPower * 1.5, // Max HP reduction amount
         healRatio: 2.0, // Heal 2x the amount reduced + gain max HP
         weight: 20,
@@ -204,8 +204,8 @@ export const mechSpiderData: BossData = {
                     description: '体内の修理装置で生命体に栄養剤を注入する',
                     messages: [
                         'REPAIR SYSTEM ACTIVE...',
-                        '<USER>の体内修理装置が<TARGET>に栄養剤を注入している...',
-                        '修理装置に拘束されて動けない<TARGET>は、栄養剤を飲まされ続ける...'
+                        '{boss}の体内修理装置が{player}に栄養剤を注入している...',
+                        '修理装置に拘束されて動けない{player}は、栄養剤を飲まされ続ける...'
                     ],
                     weight: 1
                 },
@@ -216,8 +216,8 @@ export const mechSpiderData: BossData = {
                     description: '体内の機械腕で生命体をマッサージする',
                     messages: [
                         'MASSAGE PROTOCOL INITIATED...',
-                        '<USER>の体内マッサージ機が<TARGET>の体を挟み込む...',
-                        '<TARGET>は機械的なマッサージを受けている...'
+                        '{boss}の体内マッサージ機が{player}の体を挟み込む...',
+                        '{player}は機械的なマッサージを受けている...'
                     ],
                     weight: 1
                 },
@@ -228,7 +228,7 @@ export const mechSpiderData: BossData = {
                     description: '意味のない修理作業を生命体に施し続ける',
                     messages: [
                         'PROCESSING REPAIR SEQUENCE...',
-                        '<USER>が<TARGET>にがらくたのようなパーツを接着しようとする...',
+                        '{boss}が{player}にがらくたのようなパーツを接着しようとする...',
                         'しかし、糊でくっつけられたパーツはすぐに外れてしまう...'
                     ],
                     weight: 1
@@ -240,8 +240,8 @@ export const mechSpiderData: BossData = {
                     description: '体内の拘束システムで生命体を固定し続ける',
                     messages: [
                         'RESTRAINT SYSTEM ACTIVE...',
-                        '<USER>の体内拘束システムが<TARGET>を固定している...',
-                        '<TARGET>は機械的な拘束から逃れられない...'
+                        '{boss}の体内拘束システムが{player}を固定している...',
+                        '{player}は機械的な拘束から逃れられない...'
                     ],
                     weight: 1
                 },
@@ -252,8 +252,8 @@ export const mechSpiderData: BossData = {
                     description: '修理が完了したか生命体を検査し続ける',
                     messages: [
                         'REPAIR INSPECTION PROTOCOL...',
-                        '<USER>が<TARGET>の修理完了を検査している...',
-                        '不整合を検知した<USER>は<TARGET>の修理を続ける...'
+                        '{boss}が{player}の修理完了を検査している...',
+                        '不整合を検知した{boss}は{player}の修理を続ける...'
                     ],
                     weight: 1
                 }
@@ -406,10 +406,10 @@ mechSpiderData.getDialogue = function(situation: 'battle-start' | 'player-restra
 // Special finishing move sequence for cocoon doomed state
 mechSpiderData.finishingMove = function(): string[] {
     return [
-        '<TARGET>は繭の中で完全に小さくなってしまった...',
-        '機械のクモは繭に噛みつき、中身を<TARGET>ごと吸い上げる！',
-        '<TARGET>が機械のクモの体内に取り込まれた！',
-        '機械のクモは体内の<TARGET>を合成糸で拘束し、体内修理装置に縛りつける！',
-        '修理装置に縛り付けられた<TARGET>は、機械のクモが満足するまで意味のない修理をされ続ける...',
+        '{player}は繭の中で完全に小さくなってしまった...',
+        '機械のクモは繭に噛みつき、中身を{player}ごと吸い上げる！',
+        '{player}が機械のクモの体内に取り込まれた！',
+        '機械のクモは体内の{player}を合成糸で拘束し、体内修理装置に縛りつける！',
+        '修理装置に縛り付けられた{player}は、機械のクモが満足するまで意味のない修理をされ続ける...',
     ];
 };

--- a/src/game/data/bosses/mikan-dragon.ts
+++ b/src/game/data/bosses/mikan-dragon.ts
@@ -7,7 +7,7 @@ const mikanDragonActions: BossAction[] = [
         type: ActionType.Attack,
         name: '蜜柑の爪',
         description: '蜜柑のような鋭い爪で攻撃',
-        messages: ['<USER>は蜜柑のような鋭い爪で<TARGET>を攻撃した！'],
+        messages: ['{boss}は蜜柑のような鋭い爪で{player}を攻撃した！'],
         damageFormula: (user: Boss) => user.attackPower * 0.9,
         weight: 25,
         playerStateCondition: 'normal'
@@ -17,7 +17,7 @@ const mikanDragonActions: BossAction[] = [
         type: ActionType.Attack,
         name: '蜜柑の尻尾',
         description: '蜜柑色の尻尾で叩く',
-        messages: ['<USER>は蜜柑色の尻尾で<TARGET>を叩いた！'],
+        messages: ['{boss}は蜜柑色の尻尾で{player}を叩いた！'],
         damageFormula: (user: Boss) => user.attackPower * 1.1,
         weight: 20,
         playerStateCondition: 'normal'
@@ -27,7 +27,7 @@ const mikanDragonActions: BossAction[] = [
         type: ActionType.StatusAttack,
         name: '蜜柑の香り',
         description: '甘い蜜柑の香りで獲物を魅了する',
-        messages: ['<USER>は甘い蜜柑の香りを放った！'],
+        messages: ['{boss}は甘い蜜柑の香りを放った！'],
         damageFormula: (user: Boss) => user.attackPower * 0.6,
         hitRate: 0.9,
         statusEffect: StatusEffectType.Charm,
@@ -44,7 +44,7 @@ const mikanDragonActions: BossAction[] = [
         type: ActionType.StatusAttack,
         name: '蜜柑の粘液',
         description: '蜜柑の汁のような粘液で獲物をネバネバにする',
-        messages: ['<USER>は口から蜜柑のような粘液を放った！'],
+        messages: ['{boss}は口から蜜柑のような粘液を放った！'],
         damageFormula: (user: Boss) => user.attackPower * 0.7,
         hitRate: 0.95,
         statusEffect: StatusEffectType.Slimed,
@@ -57,7 +57,7 @@ const mikanDragonActions: BossAction[] = [
         description: '長い舌で獲物を拘束する',
         messages: [
             '「フルルル...」',
-            '<USER>は長い舌で<TARGET>を巻き付けてきた！'
+            '{boss}は長い舌で{player}を巻き付けてきた！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         weight: 15,
@@ -73,7 +73,7 @@ const mikanDragonActions: BossAction[] = [
         description: '舌で獲物を締め付ける',
         messages: [
             '「フルルル...」',
-            '<USER>は巻き付けた舌で<TARGET>を締め付ける！'
+            '{boss}は巻き付けた舌で{player}を締め付ける！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.3,
         weight: 30,
@@ -86,7 +86,7 @@ const mikanDragonActions: BossAction[] = [
         description: '舌で獲物を舐めて体力を吸収する',
         messages: [
             '「フルルル...」',
-            '<USER>は<TARGET>を体ごとキスして体力を吸収する！'
+            '{boss}は{player}を体ごとキスして体力を吸収する！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.6,
         weight: 25,
@@ -100,7 +100,7 @@ const mikanDragonActions: BossAction[] = [
         description: '舌を口に入れて蜜柑の汁を注入し、魅了する',
         messages: [
             '「フルルル...」',
-            '<USER>は舌を<TARGET>の口に入れて蜜柑の汁を注入している！'
+            '{boss}は舌を{player}の口に入れて蜜柑の汁を注入している！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.1,
         statusEffect: StatusEffectType.Charm,
@@ -149,8 +149,8 @@ export const mikanDragonData: BossData = {
                     description: '獲物の体を蜜柑の汁で満たし、培養し続ける',
                     messages: [
                         '「フルルル...」',
-                        '<USER>の体内で蜜柑の汁が<TARGET>を培養している...',
-                        '<TARGET>の体は徐々に蜜柑ドラゴンの幼体のような姿に変わっていく...'
+                        '{boss}の体内で蜜柑の汁が{player}を培養している...',
+                        '{player}の体は徐々に蜜柑ドラゴンの幼体のような姿に変わっていく...'
                     ],
                     statusEffect: StatusEffectType.Charm,
                     weight: 1
@@ -162,8 +162,8 @@ export const mikanDragonData: BossData = {
                     description: '体内触手で獲物を優しく愛撫し続ける',
                     messages: [
                         '「フルルル...」',
-                        '<USER>の体内触手が<TARGET>を優しく愛撫している...',
-                        '<TARGET>は徐々に抵抗する意志を失っていく...'
+                        '{boss}の体内触手が{player}を優しく愛撫している...',
+                        '{player}は徐々に抵抗する意志を失っていく...'
                     ],
                     statusEffect: StatusEffectType.Lethargy,
                     weight: 1
@@ -175,8 +175,8 @@ export const mikanDragonData: BossData = {
                     description: '蜜柑の汁を注入して獲物を同族化させる',
                     messages: [
                         '「フルルル...」',
-                        '<USER>が<TARGET>に大量の蜜柑汁を注入している...',
-                        '<TARGET>の体は蜜柑ドラゴンの幼体へと変化している...'
+                        '{boss}が{player}に大量の蜜柑汁を注入している...',
+                        '{player}の体は蜜柑ドラゴンの幼体へと変化している...'
                     ],
                     statusEffect: StatusEffectType.Charm,
                     weight: 1
@@ -195,7 +195,7 @@ export const mikanDragonData: BossData = {
                     description: '体内触手で蜜柑の汁を注入し、最大HPを減らす',
                     messages: [
                         '「フルルル...」',
-                        '<USER>の体内触手が<TARGET>の口に蜜柑汁を注入している！'
+                        '{boss}の体内触手が{player}の口に蜜柑汁を注入している！'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 1.5,
                     statusEffect: StatusEffectType.Charm,
@@ -208,7 +208,7 @@ export const mikanDragonData: BossData = {
                     description: '蜜柑の果肉のような胃壁でマッサージし、最大HPを減らす',
                     messages: [
                         '「フルルル...」',
-                        '<USER>の胃壁が<TARGET>を蜜柑の果肉のように優しくマッサージしている！'
+                        '{boss}の胃壁が{player}を蜜柑の果肉のように優しくマッサージしている！'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 2.2,
                     weight: 1
@@ -220,7 +220,7 @@ export const mikanDragonData: BossData = {
                     description: '体内触手でくすぐり、最大HPを減らして脱力状態にする',
                     messages: [
                         '「フルルル...」',
-                        '<USER>の体内触手が<TARGET>をくすぐっている！'
+                        '{boss}の体内触手が{player}をくすぐっている！'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 1.6,
                     statusEffect: StatusEffectType.Lethargy,
@@ -242,7 +242,7 @@ export const mikanDragonData: BossData = {
                         description: '拘束した獲物を丸呑みする',
                         messages: [
                             '「フルルル...」',
-                            '<USER>が大きな口を開け、<TARGET>を丸呑みにする！'
+                            '{boss}が大きな口を開け、{player}を丸呑みにする！'
                         ],
                         weight: 1
                     };
@@ -258,7 +258,7 @@ export const mikanDragonData: BossData = {
                         description: '長い舌で獲物を拘束する',
                         messages: [
                             '「フルルル...」',
-                            '<USER>は長い舌で<TARGET>を巻き付けてきた！'
+                            '{boss}は長い舌で{player}を巻き付けてきた！'
                         ],
                         weight: 1
                     };
@@ -270,7 +270,7 @@ export const mikanDragonData: BossData = {
                         description: '拘束した獲物を丸呑みする',
                         messages: [
                             '「フルルル...」',
-                            '<USER>が大きな口を開け、<TARGET>を丸呑みにする！'
+                            '{boss}が大きな口を開け、{player}を丸呑みにする！'
                         ],
                         weight: 1
                     };
@@ -336,8 +336,8 @@ export const mikanDragonData: BossData = {
 mikanDragonData.finishingMove = function() {
     return [
         '「フルルル...」',
-        '<USER>の体内触手が<TARGET>を胃袋の奥へと縛り付ける...',
-        '<TARGET>は蜜柑の粘液に満たされれた体内で<USER>の幼体として培養されることになった...'
+        '{boss}の体内触手が{player}を胃袋の奥へと縛り付ける...',
+        '{player}は蜜柑の粘液に満たされれた体内で{boss}の幼体として培養されることになった...'
     ];
 };
 

--- a/src/game/data/bosses/scorpion-carrier.ts
+++ b/src/game/data/bosses/scorpion-carrier.ts
@@ -8,7 +8,7 @@ const scorpionCarrierActions: BossAction[] = [
         type: ActionType.Attack,
         name: 'はさみ攻撃',
         description: '大きなはさみで攻撃する',
-        messages: ['<USER>は大きなはさみで<TARGET>を挟みつけようとする！'],
+        messages: ['{boss}は大きなはさみで{player}を挟みつけようとする！'],
         damageFormula: (user: Boss) => user.attackPower * 1.25,
         hitRate: 0.8,
         weight: 20
@@ -18,7 +18,7 @@ const scorpionCarrierActions: BossAction[] = [
         type: ActionType.Attack,
         name: '踏みつけ',
         description: 'タイヤの足で踏みつける',
-        messages: ['<USER>はタイヤの足で<TARGET>を踏みつけようとする！'],
+        messages: ['{boss}はタイヤの足で{player}を踏みつけようとする！'],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         hitRate: 0.9,
         weight: 15
@@ -28,7 +28,7 @@ const scorpionCarrierActions: BossAction[] = [
         type: ActionType.Attack,
         name: 'しっぽ振り回し',
         description: '強力だが命中率が低い攻撃',
-        messages: ['<USER>は巨大な注射器のような尻尾を振り回す！'],
+        messages: ['{boss}は巨大な注射器のような尻尾を振り回す！'],
         damageFormula: (user: Boss) => user.attackPower * 2.5,
         hitRate: 0.6,
         weight: 10,
@@ -39,7 +39,7 @@ const scorpionCarrierActions: BossAction[] = [
         type: ActionType.StatusAttack,
         name: 'しっぽ麻酔',
         description: '尻尾の注射器で麻酔を注入する',
-        messages: ['<USER>は尻尾の注射器で<TARGET>に麻酔を注入しようとする！'],
+        messages: ['{boss}は尻尾の注射器で{player}に麻酔を注入しようとする！'],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         statusEffect: StatusEffectType.Anesthesia,
         statusChance: 0.70,
@@ -54,7 +54,7 @@ const scorpionCarrierActions: BossAction[] = [
         type: ActionType.RestraintAttack,
         name: 'はさみキャッチ',
         description: 'はさみで対象を捕まえる',
-        messages: ['<USER>は巨大なはさみで<TARGET>を捕まえようとする！'],
+        messages: ['{boss}は巨大なはさみで{player}を捕まえようとする！'],
         damageFormula: (user: Boss) => user.attackPower * 0.6,
         weight: 25,
         canUse: (_boss, player, _turn) => {
@@ -70,7 +70,7 @@ const scorpionCarrierActionsRestrained: BossAction[] = [
         type: ActionType.StatusAttack,
         name: '猛毒注射',
         description: '拘束した対象に猛毒を注射する',
-        messages: ['<USER>は拘束した<TARGET>に猛毒を注射する！'],
+        messages: ['{boss}は拘束した{player}に猛毒を注射する！'],
         damageFormula: (user: Boss) => user.attackPower * 1.9,
         statusEffect: StatusEffectType.ScorpionPoison,
         statusChance: 0.90,
@@ -82,7 +82,7 @@ const scorpionCarrierActionsRestrained: BossAction[] = [
         type: ActionType.Attack,
         name: 'かみつき舐め回し',
         description: '拘束した対象を舐め回す',
-        messages: ['<USER>は拘束した<TARGET>を舐め回す！'],
+        messages: ['{boss}は拘束した{player}を舐め回す！'],
         damageFormula: (user: Boss) => user.attackPower * 2.25,
         weight: 25
     },
@@ -91,7 +91,7 @@ const scorpionCarrierActionsRestrained: BossAction[] = [
         type: ActionType.Attack,
         name: 'はさみ攻撃',
         description: '大きなはさみで攻撃する',
-        messages: ['<USER>は大きなはさみで<TARGET>を挟みつける！'],
+        messages: ['{boss}は大きなはさみで{player}を挟みつける！'],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         weight: 20
     }
@@ -105,8 +105,8 @@ const scorpionCarrierActionsKnockoutRestrained: BossAction[] = [
         name: '大胆に丸呑み',
         description: '対象を丸呑みして体内に運ぶ',
         messages: [
-            '<USER>は<TARGET>を大胆に丸呑みする！',
-            '<TARGET>がサソリの体内に取り込まれる！'
+            '{boss}は{player}を大胆に丸呑みする！',
+            '{player}がサソリの体内に取り込まれる！'
         ],
         weight: 1,
         canUse: (_boss, player, _turn) => {
@@ -123,7 +123,7 @@ const scorpionCarrierActionsEaten: BossAction[] = [
         type: ActionType.StatusAttack,
         name: '脱力剤注入',
         description: '体内の生き物に脱力剤を注入する',
-        messages: ['<USER>は体内の注射器で<TARGET>に脱力剤を注入する！'],
+        messages: ['{boss}は体内の注射器で{player}に脱力剤を注入する！'],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         statusEffect: StatusEffectType.Weakening,
         statusChance: 0.80,
@@ -136,7 +136,7 @@ const scorpionCarrierActionsEaten: BossAction[] = [
         type: ActionType.DevourAttack,
         name: '体内マッサージ',
         description: '体内の生き物にマッサージして最大HPを吸収',
-        messages: ['<USER>は体内で<TARGET>をマッサージし、エネルギーを吸収する！'],
+        messages: ['{boss}は体内で{player}をマッサージし、エネルギーを吸収する！'],
         damageFormula: (user: Boss) => user.attackPower * 1.5, // Max HP reduction amount
         weight: 30,
         playerStateCondition: 'eaten',
@@ -149,7 +149,7 @@ const scorpionCarrierActionsEaten: BossAction[] = [
         type: ActionType.DevourAttack,
         name: '体内締め付け',
         description: '体内で生き物を締め付けて最大HPを吸収',
-        messages: ['<USER>は体内で<TARGET>を締め付け、エネルギーを吸収する！'],
+        messages: ['{boss}は体内で{player}を締め付け、エネルギーを吸収する！'],
         damageFormula: (user: Boss) => user.attackPower * 1.9, // Max HP reduction amount
         weight: 25,
         playerStateCondition: 'eaten',
@@ -196,8 +196,8 @@ export const scorpionCarrierData: BossData = {
                     name: '体内運搬',
                     description: '体内の生き物を目的地まで運搬する',
                     messages: [
-                        '<USER>は体内の<TARGET>を目的地まで運搬している...',
-                        '<TARGET>はサソリの体内で消化されることはないが、エネルギーを吸収され続ける...',
+                        '{boss}は体内の{player}を目的地まで運搬している...',
+                        '{player}はサソリの体内で消化されることはないが、エネルギーを吸収され続ける...',
                         'タイヤの足音が響く中、運搬は続く...'
                     ],
                     weight: 1
@@ -208,9 +208,9 @@ export const scorpionCarrierData: BossData = {
                     name: '栄養剤注入',
                     description: '体内の生き物に栄養剤を注入する',
                     messages: [
-                        '<USER>は体内の注射器で<TARGET>に栄養剤を注入する...',
-                        '<TARGET>は強制的に栄養剤を摂取させられる...',
-                        '栄養剤によって<TARGET>の意識が朦朧としてくる...'
+                        '{boss}は体内の注射器で{player}に栄養剤を注入する...',
+                        '{player}は強制的に栄養剤を摂取させられる...',
+                        '栄養剤によって{player}の意識が朦朧としてくる...'
                     ],
                     weight: 1
                 },
@@ -220,9 +220,9 @@ export const scorpionCarrierData: BossData = {
                     name: 'エネルギー吸収',
                     description: '体内の生き物からエネルギーを吸収する',
                     messages: [
-                        '<USER>は<TARGET>からエネルギーを吸収している...',
-                        '<TARGET>のエネルギーがサソリに吸収されていく...',
-                        'エネルギーを吸収された<TARGET>は動けなくなる...'
+                        '{boss}は{player}からエネルギーを吸収している...',
+                        '{player}のエネルギーがサソリに吸収されていく...',
+                        'エネルギーを吸収された{player}は動けなくなる...'
                     ],
                     weight: 1
                 },
@@ -232,9 +232,9 @@ export const scorpionCarrierData: BossData = {
                     name: 'マナ吸収',
                     description: '体内の生き物からマナを吸収する',
                     messages: [
-                        '<USER>は<TARGET>からマナを吸収している...',
-                        '<TARGET>のマナがサソリに吸収されていく...',
-                        'マナを吸収された<TARGET>は魔法が使えなくなる...'
+                        '{boss}は{player}からマナを吸収している...',
+                        '{player}のマナがサソリに吸収されていく...',
+                        'マナを吸収された{player}は魔法が使えなくなる...'
                     ],
                     weight: 1
                 },
@@ -244,9 +244,9 @@ export const scorpionCarrierData: BossData = {
                     name: '体内薬剤循環',
                     description: '体内で薬剤を循環させて生き物を無力化する',
                     messages: [
-                        '<USER>は体内で薬剤を循環させている...',
-                        '<TARGET>は薬剤によって完全に無力化される...',
-                        '薬剤の効果で<TARGET>は抵抗する力を失う...'
+                        '{boss}は体内で薬剤を循環させている...',
+                        '{player}は薬剤によって完全に無力化される...',
+                        '薬剤の効果で{player}は抵抗する力を失う...'
                     ],
                     weight: 1
                 }
@@ -382,9 +382,9 @@ scorpionCarrierData.getDialogue = function(situation: 'battle-start' | 'player-r
 // Special finishing move sequence for eaten doomed state
 scorpionCarrierData.finishingMove = function(): string[] {
     return [
-        'サソリは体内の<TARGET>を完全に支配下に置く！',
-        '<TARGET>はサソリの体内で永遠に運搬され続ける！',
+        'サソリは体内の{player}を完全に支配下に置く！',
+        '{player}はサソリの体内で永遠に運搬され続ける！',
         'サソリは満足そうに砂漠を歩き始める...',
-        '<TARGET>は運び屋のサソリの永遠の荷物となった...',
+        '{player}は運び屋のサソリの永遠の荷物となった...',
     ];
 };

--- a/src/game/data/bosses/sea-kraken.ts
+++ b/src/game/data/bosses/sea-kraken.ts
@@ -34,8 +34,8 @@ const seaKrakenActions: BossAction[] = [
         weight: 25,
         messages: [
             '「グゥゥゥ...」',
-            '<USER>が黒いイカスミを吐き出した！',
-            '<TARGET>の視界が阻害される！'
+            '{boss}が黒いイカスミを吐き出した！',
+            '{player}の視界が阻害される！'
         ]
     },
     {
@@ -45,7 +45,7 @@ const seaKrakenActions: BossAction[] = [
         description: '長い触腕で対象を拘束する',
         messages: [
             '「グルルル...」',
-            '<USER>の触腕が<TARGET>に巻き付いた！',
+            '{boss}の触腕が{player}に巻き付いた！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.9,
         weight: 10,
@@ -60,7 +60,7 @@ const seaKrakenActions: BossAction[] = [
         description: '拘束中の獲物を吸盤で吸引し、エネルギーを吸収する',
         messages: [
             '「シュゥゥゥ...」',
-            '<USER>の触腕が<TARGET>を強く吸引する！',
+            '{boss}の触腕が{player}を強く吸引する！',
             'エネルギーが吸収されていく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.3,
@@ -75,8 +75,8 @@ const seaKrakenActions: BossAction[] = [
         description: '拘束中の獲物にイカスミを注入し、魅了状態にする',
         messages: [
             '「ゴポポポ...」',
-            '<USER>が触腕を<TARGET>の口に入れてイカスミを注入した！',
-            '<TARGET>は催眠効果で魅了されてしまう...'
+            '{boss}が触腕を{player}の口に入れてイカスミを注入した！',
+            '{player}は催眠効果で魅了されてしまう...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.5,
         weight: 30,
@@ -125,8 +125,8 @@ export const seaKrakenData: BossData = {
                     description: '獲物をイカスミ漬けにしながら体力を吸収し続ける',
                     messages: [
                         '「ゴポポポ...」',
-                        '<USER>の体内でイカスミが<TARGET>を包み込んでいる...',
-                        '<TARGET>は催眠状態のまま体力を吸収され続ける...'
+                        '{boss}の体内でイカスミが{player}を包み込んでいる...',
+                        '{player}は催眠状態のまま体力を吸収され続ける...'
                     ],
                     statusEffect: StatusEffectType.Charm,
                     weight: 1
@@ -138,8 +138,8 @@ export const seaKrakenData: BossData = {
                     description: '体内の無数の吸盤で獲物の体力を永遠に吸収し続ける',
                     messages: [
                         '「シュゥゥゥ...」',
-                        '<USER>の胃袋の吸盤が<TARGET>を吸引している...',
-                        '<TARGET>のエネルギーが永遠に吸収されていく...'
+                        '{boss}の胃袋の吸盤が{player}を吸引している...',
+                        '{player}のエネルギーが永遠に吸収されていく...'
                     ],
                     statusEffect: StatusEffectType.Weakness,
                     weight: 1
@@ -158,7 +158,7 @@ export const seaKrakenData: BossData = {
                     description: '体内の獲物のエネルギーを、胃袋にある無数の吸盤で吸収する',
                     messages: [
                         '「シュゥゥゥ...」',
-                        '<USER>の胃袋の吸盤が<TARGET>を強く吸引している！'
+                        '{boss}の胃袋の吸盤が{player}を強く吸引している！'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 2.0,
                     weight: 1
@@ -170,8 +170,8 @@ export const seaKrakenData: BossData = {
                     description: '体内の獲物をイカスミ漬けにして最大体力を吸収する',
                     messages: [
                         '「ゴポポポ...」',
-                        '<USER>の体内でイカスミが<TARGET>を包み込む！',
-                        '<TARGET>は催眠状態になってしまった...'
+                        '{boss}の体内でイカスミが{player}を包み込む！',
+                        '{player}は催眠状態になってしまった...'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 1.3,
                     statusEffect: StatusEffectType.Charm,
@@ -193,8 +193,8 @@ export const seaKrakenData: BossData = {
                         description: '拘束した獲物を口に押し込み丸呑みする',
                         messages: [
                             '「グォォォ！」',
-                            '<USER>が<TARGET>を触腕ごと大きな口に押し込んだ！',
-                            '<TARGET>は体内に飲み込まれてしまった！'
+                            '{boss}が{player}を触腕ごと大きな口に押し込んだ！',
+                            '{player}は体内に飲み込まれてしまった！'
                         ],
                         weight: 1
                     };
@@ -210,7 +210,7 @@ export const seaKrakenData: BossData = {
                         description: '対象を触腕で拘束する',
                         messages: [
                             '「グルルル...」',
-                            '<USER>の触腕が<TARGET>に巻き付いた！'
+                            '{boss}の触腕が{player}に巻き付いた！'
                         ],
                         weight: 1
                     };
@@ -222,7 +222,7 @@ export const seaKrakenData: BossData = {
                         description: '獲物を丸呑みする',
                         messages: [
                             '「グォォォ！」',
-                            '<USER>が大きな口を開け、<TARGET>を丸呑みにする！'
+                            '{boss}が大きな口を開け、{player}を丸呑みにする！'
                         ],
                         weight: 1
                     };
@@ -280,8 +280,8 @@ export const seaKrakenData: BossData = {
 seaKrakenData.finishingMove = function() {
     return [
         '「グルルル...」',
-        '<USER>の胃袋吸盤が<TARGET>の腕と脚を吸い込み、体全体を吸盤で拘束する！',
-        '<TARGET>はイカスミを注入されながら吸盤で吸収され続け、<USER>の体内でエネルギーを永遠に吸収されることになった...'
+        '{boss}の胃袋吸盤が{player}の腕と脚を吸い込み、体全体を吸盤で拘束する！',
+        '{player}はイカスミを注入されながら吸盤で吸収され続け、{boss}の体内でエネルギーを永遠に吸収されることになった...'
     ];
 };
 

--- a/src/game/data/bosses/seraph-mascot.ts
+++ b/src/game/data/bosses/seraph-mascot.ts
@@ -11,7 +11,7 @@ const seraphMascotContactActions: BossAction[] = [
         description: '巨大な手でやさしく撫でようとする',
         messages: [
             '「だいじょうぶだよ〜♪」',
-            '<USER>は<TARGET>を優しく撫でようとする！',
+            '{boss}は{player}を優しく撫でようとする！',
             'しかし、あまりにも大きすぎて...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.6,
@@ -26,8 +26,8 @@ const seraphMascotContactActions: BossAction[] = [
         description: '神聖な光で対象を祝福する',
         messages: [
             '「みんなで幸せになろうね〜♪」',
-            '<USER>は<TARGET>に神聖な光を浴びせる！',
-            '<TARGET>が祝福の光に包まれた！'
+            '{boss}は{player}に神聖な光を浴びせる！',
+            '{player}が祝福の光に包まれた！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.4,
         statusEffect: StatusEffectType.Blessed,
@@ -42,8 +42,8 @@ const seraphMascotContactActions: BossAction[] = [
         description: '巨大すぎる存在感で相手を圧倒する',
         messages: [
             '「あれ？怖がらないで〜」',
-            '<USER>の巨大な存在感が<TARGET>を圧倒する！',
-            '<TARGET>は巨大さに圧倒されてしまった！'
+            '{boss}の巨大な存在感が{player}を圧倒する！',
+            '{player}は巨大さに圧倒されてしまった！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.3,
         statusEffect: StatusEffectType.Overwhelmed,
@@ -58,7 +58,7 @@ const seraphMascotContactActions: BossAction[] = [
         description: '頭の上の輪っかが落ちそうになる',
         messages: [
             '「あっ、わっかが〜！」',
-            '<USER>の頭上の輪っかが<TARGET>の方へ落ちてくる！'
+            '{boss}の頭上の輪っかが{player}の方へ落ちてくる！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.1,
         hitRate: 0.85,
@@ -72,8 +72,8 @@ const seraphMascotContactActions: BossAction[] = [
         description: '大きな翼で優しく抱きしめる',
         messages: [
             '「抱っこしてあげる〜♪」',
-            '<USER>は大きな翼で<TARGET>を包み込む！',
-            '<TARGET>が翼に包まれて動けなくなった！'
+            '{boss}は大きな翼で{player}を包み込む！',
+            '{player}が翼に包まれて動けなくなった！'
         ],
         weight: 25,
         canUse: (_boss, player, _turn) => {
@@ -91,8 +91,8 @@ const seraphMascotCareActions: BossAction[] = [
         description: '不幸を取り除くため長い舌で舐め回す',
         messages: [
             '「不幸を取ってあげるね〜♪」',
-            '<USER>は長い舌で<TARGET>を丁寧に舐め回す！',
-            '<TARGET>は救済の粘液でベトベトになった！'
+            '{boss}は長い舌で{player}を丁寧に舐め回す！',
+            '{player}は救済の粘液でベトベトになった！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.3,
         statusEffect: StatusEffectType.Slimed,
@@ -107,8 +107,8 @@ const seraphMascotCareActions: BossAction[] = [
         description: '本格的な救済のため特別な状態にする',
         messages: [
             '「もっとちゃんと救済してあげなきゃ〜♪」',
-            '<USER>は<TARGET>をより深い救済状態へと導く！',
-            '<TARGET>は救済の準備が整った状態になった！'
+            '{boss}は{player}をより深い救済状態へと導く！',
+            '{player}は救済の準備が整った状態になった！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.0,
         statusEffect: StatusEffectType.SalvationState,
@@ -123,7 +123,7 @@ const seraphMascotCareActions: BossAction[] = [
         description: '守ろうとして強く抱きしめる',
         messages: [
             '「守ってあげる〜♪」',
-            '<USER>は<TARGET>を強く抱きしめる！',
+            '{boss}は{player}を強く抱きしめる！',
             'しかし力が強すぎて...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.6,
@@ -141,8 +141,8 @@ const seraphMascotProtectionActions: BossAction[] = [
         description: '体内の聖域で完全に保護する',
         messages: [
             '「ここなら絶対安全だよ〜♪」',
-            '<USER>の体内で<TARGET>が聖なる光に包まれる！',
-            '<TARGET>の生命力が聖域で吸収されていく...'
+            '{boss}の体内で{player}が聖なる光に包まれる！',
+            '{player}の生命力が聖域で吸収されていく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.8,
         weight: 30,
@@ -155,8 +155,8 @@ const seraphMascotProtectionActions: BossAction[] = [
         description: '神聖な力で対象を浄化する',
         messages: [
             '「不純なものを取り除いてあげるね〜♪」',
-            '<USER>の体内で神聖な力が<TARGET>を浄化する！',
-            '<TARGET>の最大HPが聖なる力で削られていく...'
+            '{boss}の体内で神聖な力が{player}を浄化する！',
+            '{player}の最大HPが聖なる力で削られていく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 2.2,
         weight: 25,
@@ -169,8 +169,8 @@ const seraphMascotProtectionActions: BossAction[] = [
         description: '祝福と共に生命力を吸収する',
         messages: [
             '「たくさん祝福してあげるね〜♪」',
-            '<USER>は<TARGET>を祝福しながら生命力を吸収する！',
-            '<TARGET>は至福の中で力を奪われていく...'
+            '{boss}は{player}を祝福しながら生命力を吸収する！',
+            '{player}は至福の中で力を奪われていく...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 2.0,
         statusEffect: StatusEffectType.Blessed,
@@ -185,8 +185,8 @@ const seraphMascotProtectionActions: BossAction[] = [
         description: '永続的な救済サイクルを開始する',
         messages: [
             '「ずっと救済してあげるからね〜♪」',
-            '<USER>は<TARGET>を永続的な救済サイクルに組み込む！',
-            '<TARGET>は救済の輪の中で循環し続ける...'
+            '{boss}は{player}を永続的な救済サイクルに組み込む！',
+            '{player}は救済の輪の中で循環し続ける...'
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.5,
         statusEffect: StatusEffectType.SalvationState,
@@ -205,7 +205,7 @@ const seraphMascotEternalActions: BossAction[] = [
         description: '永遠に世話をし続ける',
         messages: [
             '「ずっとお世話してあげるからね〜♪」',
-            '<USER>は体内の<TARGET>を永続的にお世話し続けている...',
+            '{boss}は体内の{player}を永続的にお世話し続けている...',
             'でも、お世話が丁寧すぎて疲れてしまう...'
         ],
         weight: 30,
@@ -218,7 +218,7 @@ const seraphMascotEternalActions: BossAction[] = [
         description: '過度に保護しようとする',
         messages: [
             '「危ないものから守ってあげなきゃ〜！」',
-            '<USER>は体内の<TARGET>を聖なる力で過度に保護しようとする！',
+            '{boss}は体内の{player}を聖なる力で過度に保護しようとする！',
             '何もかもから守ろうとして、自由を奪ってしまう...'
         ],
         statusEffect: StatusEffectType.SalvationState,
@@ -233,8 +233,8 @@ const seraphMascotEternalActions: BossAction[] = [
         description: '救済への強迫観念が発動する',
         messages: [
             '「まだ救済が足りない！もっと、もっと〜！」',
-            '<USER>の救済への強迫観念が暴走し、体内の<TARGET>を締め付ける！',
-            '<TARGET>は完璧な救済を求められ続ける...'
+            '{boss}の救済への強迫観念が暴走し、体内の{player}を締め付ける！',
+            '{player}は完璧な救済を求められ続ける...'
         ],
         weight: 20,
         playerStateCondition: 'defeated'
@@ -246,7 +246,7 @@ const seraphMascotEternalActions: BossAction[] = [
         description: '愛情が深すぎて息ができなくなる',
         messages: [
             '「だいすき〜♪ ずっと一緒にいようね〜♪」',
-            '<USER>の深すぎる愛情で<TARGET>を体内できつく抱きしめ、息苦しくさせる！',
+            '{boss}の深すぎる愛情で{player}を体内できつく抱きしめ、息苦しくさせる！',
             '善意の愛情が逆に苦しみとなってしまう...'
         ],
         statusEffect: StatusEffectType.Overwhelmed,
@@ -345,8 +345,8 @@ const seraphMascotAIStrategy = (boss: Boss, player: Player, turn: number): BossA
                     description: '体内の聖域で完全に保護する',
                     messages: [
                         '「もう傷つかないように、ずっと守ってあげる〜♪」',
-                        '<USER>は<TARGET>を体内の聖域へと運ぶ！',
-                        '完全な保護のため、<TARGET>は聖なる胃袋に包まれた！'
+                        '{boss}は{player}を体内の聖域へと運ぶ！',
+                        '完全な保護のため、{player}は聖なる胃袋に包まれた！'
                     ],
                     weight: 1
                 };
@@ -526,11 +526,11 @@ export const seraphMascotData: BossData = {
 // フィニッシュムーブの実装
 seraphMascotData.finishingMove = function(): string[] {
     return [
-        'セラフィムマスコットは<TARGET>を完全に救済した！',
+        'セラフィムマスコットは{player}を完全に救済した！',
         '「もう何も心配いらないよ〜♪ ずっとお姉さんが守ってあげるからね〜♪」',
-        '<TARGET>はセラフィムマスコットの体内でずっと保護を受けることになった！',
-        'セラフィムマスコットは毎日<TARGET>をお世話し続け、「今日も元気かな〜？」と優しく語りかけている...',
-        'しかし、その愛情は深すぎて、セラフィムマスコットが飽きるまで<TARGET>は外の世界を見ることはない...'
+        '{player}はセラフィムマスコットの体内でずっと保護を受けることになった！',
+        'セラフィムマスコットは毎日{player}をお世話し続け、「今日も元気かな〜？」と優しく語りかけている...',
+        'しかし、その愛情は深すぎて、セラフィムマスコットが飽きるまで{player}は外の世界を見ることはない...'
     ];
 };
 

--- a/src/game/data/bosses/swamp-dragon.ts
+++ b/src/game/data/bosses/swamp-dragon.ts
@@ -41,7 +41,7 @@ const swampDragonActions: BossAction[] = [
         description: '長い尻尾で対象を拘束する',
         messages: [
             '「グルル...」',
-            '<USER>は尻尾で<TARGET>を巻き付けてきた！',
+            '{boss}は尻尾で{player}を巻き付けてきた！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.9,
         weight: 10,
@@ -57,7 +57,7 @@ const swampDragonActions: BossAction[] = [
         description: '拘束中の獲物を尻尾でしめつける',
         messages: [
             '「グオオオ...」',
-            '<USER>は<TARGET>を尻尾で締め付ける！'
+            '{boss}は{player}を尻尾で締め付ける！'
         ],
         damageFormula: (user: Boss) => user.attackPower,
         weight: 40,
@@ -70,7 +70,7 @@ const swampDragonActions: BossAction[] = [
         description: '拘束中の獲物を舌でキスする（与えたダメージ分回復）',
         messages: [
             '「グルル...」',
-            '<USER>は<TARGET>の口に舌を押し付けながら深いキスをする！',
+            '{boss}は{player}の口に舌を押し付けながら深いキスをする！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.3,
         weight: 30,
@@ -142,8 +142,8 @@ export const swampDragonData: BossData = {
                     description: '深い体内で消化液を分泌し、獲物の体力を吸収し続ける',
                     messages: [
                         '「グルルル...」',
-                        '<USER>の体内奥深くで消化液がゆっくりと分泌されている...',
-                        '<TARGET>の体が徐々に体力を失っていく...'
+                        '{boss}の体内奥深くで消化液がゆっくりと分泌されている...',
+                        '{player}の体が徐々に体力を失っていく...'
                     ],
                     weight: 1
                 },
@@ -154,8 +154,8 @@ export const swampDragonData: BossData = {
                     description: '体内の壁で獲物を優しく圧迫し続ける',
                     messages: [
                         '「ウォォォ...」',
-                        '<USER>の体内の壁が<TARGET>をゆっくりと圧迫している...',
-                        '<TARGET>は深い体内で身動きが取れない...'
+                        '{boss}の体内の壁が{player}をゆっくりと圧迫している...',
+                        '{player}は深い体内で身動きが取れない...'
                     ],
                     weight: 1
                 },
@@ -166,8 +166,8 @@ export const swampDragonData: BossData = {
                     description: '体内で獲物から栄養を吸収し続ける',
                     messages: [
                         '「グルル...」',
-                        '<USER>が<TARGET>から栄養を吸収している...',
-                        '<TARGET>の体力が徐々に奪われていく...'
+                        '{boss}が{player}から栄養を吸収している...',
+                        '{player}の体力が徐々に奪われていく...'
                     ],
                     statusEffect: StatusEffectType.Weakness,
                     weight: 1
@@ -179,8 +179,8 @@ export const swampDragonData: BossData = {
                     description: '体内の温かさで獲物を包み込み続ける',
                     messages: [
                         '「ウォォォ...」',
-                        '<USER>の体内の温かさが<TARGET>を包み込んでいる...',
-                        '<TARGET>は深い体内で意識が朦朧としている...'
+                        '{boss}の体内の温かさが{player}を包み込んでいる...',
+                        '{player}は深い体内で意識が朦朧としている...'
                     ],
                     statusEffect: StatusEffectType.Sleep,
                     weight: 1
@@ -192,8 +192,8 @@ export const swampDragonData: BossData = {
                     description: '体内の筋肉で獲物を優しくマッサージし続ける',
                     messages: [
                         '「グルル...」',
-                        '<USER>の体内の筋肉が<TARGET>を優しくマッサージしている...',
-                        '<TARGET>は抵抗することができない...'
+                        '{boss}の体内の筋肉が{player}を優しくマッサージしている...',
+                        '{player}は抵抗することができない...'
                     ],
                     statusEffect: StatusEffectType.Charm,
                     weight: 1
@@ -212,7 +212,7 @@ export const swampDragonData: BossData = {
                     description: 'ネバネバな胃液を分泌して獲物を粘液まみれにする',
                     messages: [
                         '「グルルル...」',
-                        '<USER>の胃袋が<TARGET>をネバネバな胃液まみれにする！'
+                        '{boss}の胃袋が{player}をネバネバな胃液まみれにする！'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 0.9,
                     statusEffect: StatusEffectType.Slimed,
@@ -225,7 +225,7 @@ export const swampDragonData: BossData = {
                     description: '獲物を体内で締め付ける',
                     messages: [
                         '「ウォォォ...」',
-                        '<USER>の胃壁が<TARGET>の体を圧迫する！'
+                        '{boss}の胃壁が{player}の体を圧迫する！'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 1.4,
                     weight: 1
@@ -237,7 +237,7 @@ export const swampDragonData: BossData = {
                     description: '獲物を体内で優しくマッサージする',
                     messages: [
                         '「グルル...」',
-                        '<USER>の胃壁が<TARGET>を優しくマッサージしている...'
+                        '{boss}の胃壁が{player}を優しくマッサージしている...'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 1.4,
                     weight: 1
@@ -249,7 +249,7 @@ export const swampDragonData: BossData = {
                     description: '獲物の入ったお腹をゆらゆらと揺らす',
                     messages: [
                         '「ガオー...」',
-                        '<USER>がお腹を揺らして<TARGET>を翻弄している...'
+                        '{boss}がお腹を揺らして{player}を翻弄している...'
                     ],
                     damageFormula: (user: Boss) => user.attackPower * 1.4,
                     weight: 1
@@ -270,7 +270,7 @@ export const swampDragonData: BossData = {
                         description: '拘束した獲物を丸呑みする',
                         messages: [
                             '「ガオー！」',
-                            '<USER>が大きな口を開け、<TARGET>を丸呑みにする！'
+                            '{boss}が大きな口を開け、{player}を丸呑みにする！'
                         ],
                         weight: 1
                     };
@@ -288,7 +288,7 @@ export const swampDragonData: BossData = {
                         description: '対象を尻尾で拘束する',
                         messages: [
                             '「グルル...」',
-                            '<USER>は尻尾で<TARGET>を巻き付けてきた！'
+                            '{boss}は尻尾で{player}を巻き付けてきた！'
                         ],
                         weight: 1
                     };
@@ -300,7 +300,7 @@ export const swampDragonData: BossData = {
                         description: '拘束した獲物を丸呑みする',
                         messages: [
                             '「ガオー！」',
-                            '<USER>が大きな口を開け、<TARGET>を丸呑みにする！'
+                            '{boss}が大きな口を開け、{player}を丸呑みにする！'
                         ],
                         weight: 1
                     };
@@ -366,8 +366,8 @@ export const swampDragonData: BossData = {
 swampDragonData.finishingMove = function() {
     return [
         '「グルル...」',
-        '<USER>は<TARGET>を体内の奥深くに送り込む！',
-        '<TARGET>は体内奥深くに閉じ込められ、<USER>が満足するまで体力を吸収され続けることになった...'
+        '{boss}は{player}を体内の奥深くに送り込む！',
+        '{player}は体内奥深くに閉じ込められ、{boss}が満足するまで体力を吸収され続けることになった...'
     ];
 };
 

--- a/src/game/data/bosses/underground-worm.ts
+++ b/src/game/data/bosses/underground-worm.ts
@@ -10,7 +10,7 @@ const undergroundWormActions: BossAction[] = [
         description: '地面を割いて攻撃',
         messages: [
             '「グルルル...」',
-            '<USER>は地面を割って<TARGET>を攻撃した！',
+            '{boss}は地面を割って{player}を攻撃した！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.2,
         weight: 40,
@@ -24,8 +24,8 @@ const undergroundWormActions: BossAction[] = [
         description: '石を溶かす息を吐いて敵を石化させる',
         messages: [
             '「シュルシュル...」',
-            '<USER>は石を溶かす息を吐いた！',
-            '<TARGET>は石のように固まってしまった！'
+            '{boss}は石を溶かす息を吐いた！',
+            '{player}は石のように固まってしまった！'
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.8,
         hitRate: 0.75,
@@ -42,7 +42,7 @@ const undergroundWormActions: BossAction[] = [
         description: '巨大な体で相手を巻き込む',
         messages: [
             '「グオオオ...」',
-            '<USER>は巨大な体で<TARGET>を巻き込んだ！',
+            '{boss}は巨大な体で{player}を巻き込んだ！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 0.9,
         weight: 15,
@@ -57,7 +57,7 @@ const undergroundWormActions: BossAction[] = [
         description: '巨大な口で相手を呑み込む',
         messages: [
             '「ガバッ！」',
-            '<USER>は巨大な口を開いて<TARGET>を呑み込んだ！',
+            '{boss}は巨大な口を開いて{player}を呑み込んだ！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.1,
         weight: 20,
@@ -74,7 +74,7 @@ const undergroundWormDevourActions: BossAction[] = [
         name: '砂利研磨',
         description: '体内の砂利でプレイヤーを研磨する',
         messages: [
-            '<USER>の体内で砂利が<TARGET>を研磨する...',
+            '{boss}の体内で砂利が{player}を研磨する...',
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.4,
         weight: 35
@@ -85,7 +85,7 @@ const undergroundWormDevourActions: BossAction[] = [
         name: '消化液攻撃',
         description: '強酸性の消化液で溶解攻撃',
         messages: [
-            '<USER>の強酸性の消化液が<TARGET>を溶かす...',
+            '{boss}の強酸性の消化液が{player}を溶かす...',
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.7,
         weight: 40
@@ -96,7 +96,7 @@ const undergroundWormDevourActions: BossAction[] = [
         name: '石化消化',
         description: '体内で石化させて消化を遅らせる',
         messages: [
-            '<USER>の体内で特殊な消化液により<TARGET>は石化してしまった！',
+            '{boss}の体内で特殊な消化液により{player}は石化してしまった！',
         ],
         damageFormula: (user: Boss) => user.attackPower * 1.2,
         statusEffect: StatusEffectType.Petrified,
@@ -115,8 +115,8 @@ const undergroundWormPostDefeatedActions: BossAction[] = [
         name: '地底の静寂',
         description: '深い地底の静かな環境でプレイヤーを包み込む',
         messages: [
-            '<USER>は地底深くへと潜っていく...',
-            '<TARGET>は静寂な地底の暗闇に包まれ、安らかな眠りに落ちていく'
+            '{boss}は地底深くへと潜っていく...',
+            '{player}は静寂な地底の暗闇に包まれ、安らかな眠りに落ちていく'
         ],
         weight: 30,
         playerStateCondition: 'defeated'
@@ -127,8 +127,8 @@ const undergroundWormPostDefeatedActions: BossAction[] = [
         name: '鉱物吸収',
         description: '体内で地底の鉱物を使ってプレイヤーを石化保存する',
         messages: [
-            '<USER>の体内に地底の鉱物が流れ込む...',
-            '<TARGET>の体がゆっくりと美しい鉱石へと変化していく'
+            '{boss}の体内に地底の鉱物が流れ込む...',
+            '{player}の体がゆっくりと美しい鉱石へと変化していく'
         ],
         statusEffect: StatusEffectType.Petrified,
         statusChance: 0.8,
@@ -141,8 +141,8 @@ const undergroundWormPostDefeatedActions: BossAction[] = [
         name: '地下水循環',
         description: '体内の地下水系でプレイヤーを優しく循環させる',
         messages: [
-            '<USER>の体内で清らかな地下水が流れている...',
-            '<TARGET>は地下水流に包まれながら永遠の安息を得る'
+            '{boss}の体内で清らかな地下水が流れている...',
+            '{player}は地下水流に包まれながら永遠の安息を得る'
         ],
         weight: 20,
         playerStateCondition: 'defeated'
@@ -153,8 +153,8 @@ const undergroundWormPostDefeatedActions: BossAction[] = [
         name: '化石化保存',
         description: '時間をかけて獲物を化石として完全保存する',
         messages: [
-            '<USER>は獲物を大切に保存しようとしている...',
-            '<TARGET>は悠久の時を超えて保存されるため、ゆっくりと化石へと変化していく'
+            '{boss}は獲物を大切に保存しようとしている...',
+            '{player}は悠久の時を超えて保存されるため、ゆっくりと化石へと変化していく'
         ],
         weight: 15,
         playerStateCondition: 'defeated'

--- a/src/game/entities/Boss.ts
+++ b/src/game/entities/Boss.ts
@@ -7,16 +7,8 @@ import { MessageData } from '../scenes/components/BattleMessageComponent';
 // Message formatter utility
 export function formatMessage(template: string, nameUser: string, nameTarget: string): string {
     return template
-        .replace(/<USER>/g, nameUser)
-        .replace(/<TARGET>/g, nameTarget)
-}
-
-// Message formatter utility
-export function formatMessageSkill(template: string, boss: Boss, player: Player, action: BossAction): string {
-    return template
-        .replace(/<USER>/g, boss.displayName)
-        .replace(/<TARGET>/g, player.name)
-        .replace(/<ACTION>/g, action.name)
+        .replace(/{boss}/g, nameUser)
+        .replace(/{player}/g, nameTarget)
 }
 
 export enum ActionType {
@@ -37,7 +29,7 @@ export interface BossAction {
     type: ActionType;
     name: string;
     description: string;
-    messages?: string[]; // Optional messages with format specifiers: <USER>, <TARGET>, <ACTION>
+    messages?: string[]; // Optional messages with format specifiers: {boss}, {player}
     damage?: number;  // [Deprecated] Fixed damage value (use damageFormula instead)
     damageFormula?: (user: Boss) => number; // Function to calculate damage based on actor's stats
     statusEffect?: StatusEffectType;
@@ -412,7 +404,7 @@ export class Boss extends Actor {
         // Process custom messages if provided
         if (action.messages && action.messages.length > 0) {
             action.messages.forEach(messageTemplate => {
-                const formattedMessage = formatMessageSkill(messageTemplate, this, player, action);
+                const formattedMessage = formatMessage(messageTemplate, this.displayName, player.displayName);
                 messages.push(formattedMessage);
             });
         } else {


### PR DESCRIPTION
メッセージテンプレートのフォーマットを統一し、`<USER>`や`<TARGET>`から`{boss}`や`{player}`に変更しました。これにより、メッセージの一貫性が向上し、可読性が改善されます。