### PR TITLE
ゲームについての情報を追加

### DIFF
--- a/src/game/data/documents/about-this-game.md
+++ b/src/game/data/documents/about-this-game.md
@@ -1,0 +1,20 @@
+---
+id: about-this-game
+title: ElnalFTEについて
+type: default
+---
+
+# ElnalFTEについて
+
+ElnalFTEを遊んでくれてありがとう！
+
+## このゲームの作られ方
+
+ElnalFTE の 7 割位のコードは Claude Code による AI コーディングにより生成されました。残り 3 割くらいが自力らしい！
+
+## 細かい設定について
+
+- **[Github リポジトリ](https://github.com/leftonbo/eel-rpg-game)** (外部リンク)
+  - ソースコードや `docs/bosses` ディレクトリにボスの草案などが入ってます。
+- **[Notion サイト](https://tonbonotion01.notion.site/elnalfte)** (外部リンク)
+  - キャラクターやボスの設定資料が入ってます(更新頻度低)。元になった昔のキャラクターのイラスト資料もあります。


### PR DESCRIPTION
ElnalFTEに関する詳細な情報をゲーム資料に追加しました。ゲームの開発過程や設定資料へのリンクを含め、プレイヤーに向けた情報提供を強化しました。