### PR TITLE
デバッグモード表示の非表示化

### DIFF
--- a/src/templates/partials/out-game-option-scene.ejs
+++ b/src/templates/partials/out-game-option-scene.ejs
@@ -109,7 +109,7 @@
                                 <h6>ゲーム設定</h6>
                                 <div class="card bg-secondary">
                                     <div class="card-body">
-                                        <div class="form-check form-switch">
+                                        <div class="form-check form-switch d-none">
                                             <input class="form-check-input" type="checkbox" id="debug-mode-toggle">
                                             <label class="form-check-label" for="debug-mode-toggle">
                                                 デバッグモード


### PR DESCRIPTION
デバッグモードの表示を一時的に非表示にする変更を行った。これにより、ユーザーインターフェースがすっきりし、デバッグ情報が不要な場合に混乱を避けることができる。